### PR TITLE
🚀 Migrate domains from `ic0.app` to `icp0.io`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ that can be found in the LICENSE file. -->
 
 # Changelog
 
+## 1.0.0-dev.10
+
+- Migrate `ic0.app` to `icp0.io`.
+
 ## 1.0.0-dev.9
 
 - Provide AES-256-GCM encryption/decryption instead of `AES-256-CBC`. (#54)

--- a/lib/auth_client/auth_client.dart
+++ b/lib/auth_client/auth_client.dart
@@ -11,7 +11,7 @@ import 'package:meta/meta.dart';
 
 const keyLocalStorageKey = 'identity';
 const keyLocalStorageDelegation = 'delegation';
-const identityProviderDefault = 'https://identity.ic0.app';
+const identityProviderDefault = 'https://identity.icp0.io';
 const identityProviderEndpoint = '#authorize';
 
 class AuthClientCreateOptions {

--- a/lib/authentication/authentication.dart
+++ b/lib/authentication/authentication.dart
@@ -1,10 +1,10 @@
 import 'package:agent_dart/agent/auth.dart';
+import 'package:agent_dart/auth_client/auth_client.dart'
+    show identityProviderDefault;
 import 'package:agent_dart/identity/delegation.dart';
 import 'package:agent_dart/principal/principal.dart';
 import 'package:agent_dart/utils/extension.dart';
 import 'package:agent_dart/utils/is.dart';
-
-const _defaultIdentityProviderUrl = 'https://auth.ic0.app/authorize';
 
 /// Options for {@link createAuthenticationRequestUrl}.
 /// All these options may be limited further by the identity provider,
@@ -52,7 +52,8 @@ class DelegationValidChecks {
 /// options are invalid.
 Uri createAuthenticationRequestUrl(CreateUrlOptions options) {
   final url = Uri.parse(
-    options.identityProvider?.toString() ?? _defaultIdentityProviderUrl,
+    options.identityProvider?.toString() ??
+        '$identityProviderDefault/authorize',
   );
   url.queryParameters.addEntries([
     const MapEntry('response_type', 'token'),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: |
   a plugin package for dart and flutter apps.
   Developers can build ones to interact with Dfinity's blockchain directly.
 repository: https://github.com/AstroxNetwork/agent_dart
-version: 1.0.0-dev.9
+version: 1.0.0-dev.10
 
 environment:
   sdk: '>=2.17.0 <3.0.0'


### PR DESCRIPTION
https://forum.dfinity.org/t/follow-up-on-item-new-canisters-will-only-be-accessible-through-the-icp0-io-domain-existing-canisters-will-be-accessible-both-through-ic0-app-and-icp0-io/18889