### PR TITLE
🔥 Clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ that can be found in the LICENSE file. -->
 
 # Changelog
 
+## 1.0.0-dev.26
+
+- Reorg exports/imports so people can directly import `agent_dart_base/agent_dart_base.dart`
+  or `agent_dart/agent_dart.dart` without conflicts as much as possible.
+- Improve test equality checks.
+- Remove unnecessary deps.
+
 ## 1.0.0-dev.25
 
 - Prepare for monorepo.

--- a/packages/agent_dart/pubspec.yaml
+++ b/packages/agent_dart/pubspec.yaml
@@ -1,5 +1,5 @@
 name: agent_dart
-version: 1.0.0-dev.25
+version: 1.0.0-dev.26
 
 description: |
   An agent library built for Internet Computer,

--- a/packages/agent_dart_base/lib/agent/actor.dart
+++ b/packages/agent_dart_base/lib/agent/actor.dart
@@ -1,13 +1,12 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/agent/api.dart';
-import 'package:agent_dart_base/agent/canisters/management.dart';
-import 'package:agent_dart_base/agent/polling/polling.dart';
-import 'package:agent_dart_base/candid/idl.dart';
-import 'package:agent_dart_base/principal/principal.dart';
-
+import '../candid/idl.dart';
+import '../principal/principal.dart';
+import 'agent/api.dart';
+import 'canisters/management.dart';
 import 'errors.dart';
+import 'polling/polling.dart';
 import 'request_id.dart';
 import 'types.dart';
 

--- a/packages/agent_dart_base/lib/agent/agent.dart
+++ b/packages/agent_dart_base/lib/agent/agent.dart
@@ -6,6 +6,7 @@ export './utils/index.dart';
 
 export 'actor.dart';
 export 'auth.dart';
+export 'bls.dart';
 export 'cbor.dart';
 export 'certificate.dart';
 export 'errors.dart';

--- a/packages/agent_dart_base/lib/agent/agent/api.dart
+++ b/packages/agent_dart_base/lib/agent/agent/api.dart
@@ -1,7 +1,8 @@
-import 'package:agent_dart_base/agent/auth.dart';
-import 'package:agent_dart_base/agent/types.dart';
-import 'package:agent_dart_base/principal/principal.dart';
 import 'package:meta/meta.dart';
+
+import '../../principal/principal.dart';
+import '../auth.dart';
+import '../types.dart';
 
 /// Codes used by the replica for rejecting a message.
 /// See https://sdk.dfinity.org/docs/interface-spec/#reject-codes

--- a/packages/agent_dart_base/lib/agent/agent/factory.dart
+++ b/packages/agent_dart_base/lib/agent/agent/factory.dart
@@ -1,6 +1,6 @@
-import 'package:agent_dart_base/agent/agent.dart';
-import 'package:agent_dart_base/candid/idl.dart';
-import 'package:agent_dart_base/principal/principal.dart';
+import '../../candid/idl.dart';
+import '../../principal/principal.dart';
+import '../agent.dart';
 
 class AgentFactory {
   AgentFactory({

--- a/packages/agent_dart_base/lib/agent/agent/http/fetch.dart
+++ b/packages/agent_dart_base/lib/agent/agent/http/fetch.dart
@@ -3,7 +3,9 @@ import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 
-import 'index.dart';
+import '../../types.dart';
+
+// import 'index.dart';
 
 const defaultTimeout = Duration(seconds: 30);
 

--- a/packages/agent_dart_base/lib/agent/agent/http/index.dart
+++ b/packages/agent_dart_base/lib/agent/agent/http/index.dart
@@ -1,11 +1,20 @@
 import 'dart:async';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/agent/http/fetch.dart';
-import 'package:agent_dart_base/agent/cbor.dart' as cbor;
-import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:meta/meta.dart';
 import 'package:typed_data/typed_data.dart';
+
+import '../../../principal/principal.dart';
+import '../../../utils/base64.dart';
+import '../../auth.dart';
+import '../../cbor.dart' as cbor;
+import '../../errors.dart';
+import '../../request_id.dart';
+import '../../types.dart';
+import '../api.dart';
+import 'fetch.dart';
+import 'transform.dart';
+import 'types.dart';
 
 const btoa = base64Encode;
 
@@ -27,31 +36,6 @@ Future<T> withRetry<T>(
       }
       await Future.delayed(Duration(milliseconds: times * retryIntervalMills));
     }
-  }
-}
-
-enum FetchMethod {
-  get,
-  head,
-  post,
-  put,
-  delete,
-  connect,
-  options,
-  trace,
-  patch,
-}
-
-enum RequestStatusResponseStatus {
-  received,
-  processing,
-  replied,
-  rejected,
-  unknown,
-  done;
-
-  factory RequestStatusResponseStatus.fromName(String value) {
-    return values.singleWhere((e) => e.name == value);
   }
 }
 

--- a/packages/agent_dart_base/lib/agent/agent/http/transform.dart
+++ b/packages/agent_dart_base/lib/agent/agent/http/transform.dart
@@ -1,11 +1,11 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/cbor.dart';
-import 'package:agent_dart_base/agent/types.dart';
-import 'package:agent_dart_base/agent/utils/leb128.dart';
 import 'package:cbor/cbor.dart' as cbor;
 import 'package:typed_data/typed_data.dart';
 
+import '../../cbor.dart';
+import '../../types.dart';
+import '../../utils/leb128.dart';
 import 'types.dart';
 
 final _nanoSecondsPerMilliseconds = BigInt.from(1000000);

--- a/packages/agent_dart_base/lib/agent/agent/http/types.dart
+++ b/packages/agent_dart_base/lib/agent/agent/http/types.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/types.dart';
-import 'package:agent_dart_base/principal/principal.dart';
 import 'package:meta/meta.dart';
 import 'package:typed_data/typed_buffers.dart';
+
+import '../../../principal/principal.dart';
+import '../../types.dart';
 import '../api.dart';
 import 'transform.dart';
 

--- a/packages/agent_dart_base/lib/agent/agent/index.dart
+++ b/packages/agent_dart_base/lib/agent/agent/index.dart
@@ -1,6 +1,7 @@
-export './http/index.dart';
-export './http/transform.dart';
-export './http/types.dart';
 export 'api.dart';
 export 'factory.dart';
+export 'http/fetch.dart';
+export 'http/index.dart';
+export 'http/transform.dart';
+export 'http/types.dart';
 export 'proxy.dart';

--- a/packages/agent_dart_base/lib/agent/agent/proxy.dart
+++ b/packages/agent_dart_base/lib/agent/agent/proxy.dart
@@ -2,11 +2,11 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/auth.dart';
-import 'package:agent_dart_base/agent/types.dart';
-import 'package:agent_dart_base/principal/principal.dart';
 import 'package:meta/meta.dart';
 
+import '../../principal/principal.dart';
+import '../auth.dart';
+import '../types.dart';
 import 'api.dart';
 
 class ProxyMessageKind {

--- a/packages/agent_dart_base/lib/agent/auth.dart
+++ b/packages/agent_dart_base/lib/agent/auth.dart
@@ -1,10 +1,10 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/principal/principal.dart';
-import 'package:agent_dart_base/utils/extension.dart';
-import 'package:agent_dart_base/utils/u8a.dart';
 import 'package:meta/meta.dart';
 
+import '../../utils/extension.dart';
+import '../../utils/u8a.dart';
+import '../principal/principal.dart';
 import 'agent/http/types.dart';
 import 'request_id.dart';
 import 'types.dart';

--- a/packages/agent_dart_base/lib/agent/canisters/asset.dart
+++ b/packages/agent_dart_base/lib/agent/canisters/asset.dart
@@ -1,5 +1,4 @@
-import 'package:agent_dart_base/agent/actor.dart';
-
+import '../actor.dart';
 import 'asset_idl.dart';
 
 /// Create a management canister actor.

--- a/packages/agent_dart_base/lib/agent/canisters/asset_idl.dart
+++ b/packages/agent_dart_base/lib/agent/canisters/asset_idl.dart
@@ -1,7 +1,7 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/actor.dart';
-import 'package:agent_dart_base/candid/idl.dart';
+import '../../candid/idl.dart';
+import '../actor.dart';
 
 Service assetIDL() {
   return IDL.Service({

--- a/packages/agent_dart_base/lib/agent/canisters/management.dart
+++ b/packages/agent_dart_base/lib/agent/canisters/management.dart
@@ -1,6 +1,5 @@
-import 'package:agent_dart_base/agent/actor.dart';
-import 'package:agent_dart_base/principal/principal.dart';
-
+import '../../principal/principal.dart';
+import '../actor.dart';
 import 'management_idl.dart';
 
 // : ActorSubclass<ManagementCanisterRecord>

--- a/packages/agent_dart_base/lib/agent/canisters/management_idl.dart
+++ b/packages/agent_dart_base/lib/agent/canisters/management_idl.dart
@@ -1,4 +1,4 @@
-import 'package:agent_dart_base/candid/idl.dart';
+import '../../candid/idl.dart';
 
 Service managementIDL() {
   const canisterId = IDL.Principal;

--- a/packages/agent_dart_base/lib/agent/cbor.dart
+++ b/packages/agent_dart_base/lib/agent/cbor.dart
@@ -1,11 +1,11 @@
 import 'dart:math' as math;
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/principal/principal.dart';
 import 'package:cbor/cbor.dart' as cbor;
 import 'package:meta/meta.dart' show immutable;
 import 'package:typed_data/typed_data.dart';
 
+import '../principal/principal.dart';
 import 'types.dart';
 
 const _kIsWeb = bool.hasEnvironment('dart.library.js_util')

--- a/packages/agent_dart_base/lib/agent/certificate.dart
+++ b/packages/agent_dart_base/lib/agent/certificate.dart
@@ -1,16 +1,16 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/cbor.dart';
-import 'package:agent_dart_base/agent/request_id.dart';
-import 'package:agent_dart_base/agent/types.dart';
-import 'package:agent_dart_base/utils/extension.dart';
-import 'package:agent_dart_base/utils/u8a.dart';
 import 'package:typed_data/typed_data.dart';
 
+import '../../utils/extension.dart';
+import '../../utils/u8a.dart';
 import 'agent/api.dart';
 import 'bls.dart';
+import 'cbor.dart';
 import 'errors.dart';
+import 'request_id.dart';
+import 'types.dart';
 
 final AgentBLS _bls = AgentBLS();
 
@@ -52,7 +52,7 @@ class Cert {
   factory Cert.fromJson(Map json) {
     return Cert(
       delegation: json['delegation'] != null
-          ? Delegation.fromJson(Map<String, dynamic>.from(json['delegation']))
+          ? CertDelegation.fromJson(Map<String, dynamic>.from(json['delegation']))
           : null,
       signature: json['signature'] != null
           ? (json['signature'] as Uint8Buffer).buffer.asUint8List()
@@ -63,7 +63,7 @@ class Cert {
 
   final List? tree;
   final Uint8List? signature;
-  final Delegation? delegation;
+  final CertDelegation? delegation;
 
   Map<String, dynamic> toJson() {
     return {
@@ -99,14 +99,14 @@ String hashTreeToString(List tree) {
   }
 }
 
-class Delegation extends ReadStateResponse {
-  const Delegation(
+class CertDelegation extends ReadStateResponse {
+  const CertDelegation(
     this.subnetId,
     BinaryBlob certificate,
   ) : super(certificate: certificate);
 
-  factory Delegation.fromJson(Map<String, dynamic> json) {
-    return Delegation(
+  factory CertDelegation.fromJson(Map<String, dynamic> json) {
+    return CertDelegation(
       Uint8List.fromList(json['subnet_id'] as List<int>),
       json['certificate'] is Uint8List || json['certificate'] is Uint8Buffer
           ? Uint8List.fromList(json['certificate'])
@@ -159,7 +159,7 @@ class Certificate {
     }
   }
 
-  Future<Uint8List> _checkDelegation(Delegation? d) async {
+  Future<Uint8List> _checkDelegation(CertDelegation? d) async {
     if (d == null) {
       if (_rootKey == null) {
         if (_agent.rootKey != null) {

--- a/packages/agent_dart_base/lib/agent/crypto/keystore/key_store.dart
+++ b/packages/agent_dart_base/lib/agent/crypto/keystore/key_store.dart
@@ -4,18 +4,19 @@ import 'dart:convert';
 import 'dart:core';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/cbor.dart';
-import 'package:agent_dart_base/agent/crypto/random.dart';
-import 'package:agent_dart_base/identity/p256.dart';
-import 'package:agent_dart_base/identity/secp256k1.dart';
-import 'package:agent_dart_base/principal/utils/sha256.dart';
-import 'package:agent_dart_base/utils/extension.dart';
-import 'package:agent_dart_base/utils/u8a.dart';
 import 'package:agent_dart_ffi/agent_dart_ffi.dart';
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:pointycastle/export.dart';
 import 'package:uuid/uuid.dart';
+
+import '../../../identity/p256.dart';
+import '../../../identity/secp256k1.dart';
+import '../../../principal/utils/sha256.dart';
+import '../../../utils/extension.dart';
+import '../../../utils/u8a.dart';
+import '../../cbor.dart';
+import '../random.dart';
 
 part 'function.dart';
 part 'key_derivator.dart';

--- a/packages/agent_dart_base/lib/agent/crypto/random.dart
+++ b/packages/agent_dart_base/lib/agent/crypto/random.dart
@@ -1,10 +1,10 @@
 import 'dart:math' as math;
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/utils/extension.dart';
-import 'package:agent_dart_base/utils/hex.dart';
-import 'package:agent_dart_base/utils/number.dart';
-import 'package:agent_dart_base/utils/u8a.dart';
+import '../../utils/extension.dart';
+import '../../utils/hex.dart';
+import '../../utils/number.dart';
+import '../../utils/u8a.dart';
 
 const _defaultLength = 32;
 

--- a/packages/agent_dart_base/lib/agent/errors.dart
+++ b/packages/agent_dart_base/lib/agent/errors.dart
@@ -1,6 +1,6 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/utils/extension.dart';
+import '../../utils/extension.dart';
 
 /// An fetch error when using agent to make HTTP/S requests.
 class AgentFetchError extends Error {

--- a/packages/agent_dart_base/lib/agent/polling/polling.dart
+++ b/packages/agent_dart_base/lib/agent/polling/polling.dart
@@ -1,6 +1,11 @@
-import 'package:agent_dart_base/agent/agent.dart';
-import 'package:agent_dart_base/principal/principal.dart';
-import 'package:agent_dart_base/utils/extension.dart';
+import '../../../principal/principal.dart';
+import '../../../utils/extension.dart';
+import '../agent/api.dart';
+import '../agent/http/index.dart';
+import '../certificate.dart';
+import '../request_id.dart';
+import '../types.dart';
+import 'strategy.dart';
 
 export 'strategy.dart';
 

--- a/packages/agent_dart_base/lib/agent/polling/strategy.dart
+++ b/packages/agent_dart_base/lib/agent/polling/strategy.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
-import 'package:agent_dart_base/agent/agent.dart';
-import 'package:agent_dart_base/principal/principal.dart';
+import '../../principal/principal.dart';
+import '../agent.dart';
 
 typedef PollStrategyFactory = PollStrategy Function();
 typedef PollStrategy = Future<void> Function(
@@ -72,7 +72,7 @@ PollStrategy maxAttempts(int count) {
 /// Throttle polling.
 /// @param throttleMilliseconds
 /// - Amount in millisecond to wait between each polling.
-PollStrategy throttle(int throttleMilliseconds) {
+PollStrategy throttlePolling(int throttleMilliseconds) {
   return (
     Principal canisterId,
     RequestId requestId,

--- a/packages/agent_dart_base/lib/agent/request_id.dart
+++ b/packages/agent_dart_base/lib/agent/request_id.dart
@@ -1,12 +1,12 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/principal/principal.dart';
-import 'package:agent_dart_base/utils/extension.dart';
-import 'package:agent_dart_base/utils/u8a.dart';
 import 'package:crypto/crypto.dart';
 import 'package:meta/meta.dart';
 import 'package:typed_data/typed_buffers.dart';
 
+import '../../principal/principal.dart';
+import '../../utils/extension.dart';
+import '../../utils/u8a.dart';
 import 'agent/index.dart';
 import 'types.dart';
 import 'utils/leb128.dart';

--- a/packages/agent_dart_base/lib/agent/types.dart
+++ b/packages/agent_dart_base/lib/agent/types.dart
@@ -1,10 +1,35 @@
 import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/utils/extension.dart';
 import 'package:meta/meta.dart';
 
+import '../../utils/extension.dart';
 import 'utils/leb128.dart';
+
+enum FetchMethod {
+  get,
+  head,
+  post,
+  put,
+  delete,
+  connect,
+  options,
+  trace,
+  patch,
+}
+
+enum RequestStatusResponseStatus {
+  received,
+  processing,
+  replied,
+  rejected,
+  unknown,
+  done;
+
+  factory RequestStatusResponseStatus.fromName(String value) {
+    return values.singleWhere((e) => e.name == value);
+  }
+}
 
 enum BlobType { binary, der, nonce, requestId }
 

--- a/packages/agent_dart_base/lib/agent/utils/leb128.dart
+++ b/packages/agent_dart_base/lib/agent/utils/leb128.dart
@@ -1,11 +1,9 @@
-// ignore: unused_import
-import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/utils/buffer_pipe.dart';
-import 'package:agent_dart_base/utils/bn.dart';
-import 'package:agent_dart_base/utils/extension.dart';
-import 'package:agent_dart_base/utils/hex.dart';
+import '../../utils/bn.dart';
+import '../../utils/extension.dart';
+import '../../utils/hex.dart';
+import 'buffer_pipe.dart';
 
 List<T> safeRead<T>(BufferPipe<T> pipe, int ref) {
   if (pipe.length < ref) {

--- a/packages/agent_dart_base/lib/archiver/encoder.dart
+++ b/packages/agent_dart_base/lib/archiver/encoder.dart
@@ -1,11 +1,11 @@
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/agent.dart';
-import 'package:agent_dart_base/utils/extension.dart';
 import 'package:archive/archive_io.dart';
 import 'package:path/path.dart' as path;
 
+import '../agent/auth.dart';
+import '../utils/extension.dart';
 import 'signing_block.dart';
 
 class ZipSigningBlock {

--- a/packages/agent_dart_base/lib/archiver/signing_block.dart
+++ b/packages/agent_dart_base/lib/archiver/signing_block.dart
@@ -1,7 +1,8 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/agent.dart';
 import 'package:archive/archive_io.dart';
+
+import '../agent/agent.dart';
 
 class SigningBlock {
   SigningBlock.create({

--- a/packages/agent_dart_base/lib/auth_client/auth_client.dart
+++ b/packages/agent_dart_base/lib/auth_client/auth_client.dart
@@ -1,13 +1,13 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/auth.dart';
-import 'package:agent_dart_base/agent/cbor.dart';
-import 'package:agent_dart_base/authentication/authentication.dart';
-import 'package:agent_dart_base/identity/delegation.dart';
-import 'package:agent_dart_base/identity/identity.dart';
-import 'package:agent_dart_base/utils/extension.dart';
 import 'package:meta/meta.dart';
+
+import '../../utils/extension.dart';
+import '../agent/auth.dart';
+import '../agent/cbor.dart';
+import '../authentication/authentication.dart';
+import '../identity/identity.dart';
 
 const keyLocalStorageKey = 'identity';
 const keyLocalStorageDelegation = 'delegation';

--- a/packages/agent_dart_base/lib/authentication/authentication.dart
+++ b/packages/agent_dart_base/lib/authentication/authentication.dart
@@ -1,10 +1,9 @@
-import 'package:agent_dart_base/agent/auth.dart';
-import 'package:agent_dart_base/auth_client/auth_client.dart'
-    show identityProviderDefault;
-import 'package:agent_dart_base/identity/delegation.dart';
-import 'package:agent_dart_base/principal/principal.dart';
-import 'package:agent_dart_base/utils/extension.dart';
-import 'package:agent_dart_base/utils/is.dart';
+import '../agent/auth.dart';
+import '../auth_client/auth_client.dart' show identityProviderDefault;
+import '../identity/delegation.dart';
+import '../principal/principal.dart';
+import '../utils/extension.dart';
+import '../utils/is.dart';
 
 /// Options for createAuthenticationRequestUrl.
 /// All these options may be limited further by the identity provider,

--- a/packages/agent_dart_base/lib/candid/idl.dart
+++ b/packages/agent_dart_base/lib/candid/idl.dart
@@ -1,15 +1,17 @@
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
+
 import 'dart:convert';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/agent.dart';
-import 'package:agent_dart_base/principal/principal.dart' as principal;
-import 'package:agent_dart_base/utils/extension.dart';
-import 'package:agent_dart_base/utils/map.dart';
-import 'package:agent_dart_base/utils/number.dart';
-import 'package:agent_dart_base/utils/u8a.dart';
 import 'package:meta/meta.dart';
+
+import '../agent/agent.dart';
+import '../principal/principal.dart' as principal;
+import '../utils/extension.dart';
+import '../utils/map.dart';
+import '../utils/number.dart';
+import '../utils/u8a.dart';
 
 typedef Pipe<T> = BufferPipe<T>;
 typedef PrincipalId = principal.Principal;

--- a/packages/agent_dart_base/lib/identity/delegation.dart
+++ b/packages/agent_dart_base/lib/identity/delegation.dart
@@ -1,11 +1,16 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/agent.dart';
-import 'package:agent_dart_base/principal/principal.dart';
-import 'package:agent_dart_base/utils/extension.dart';
-import 'package:agent_dart_base/utils/u8a.dart';
 import 'package:cbor/cbor.dart';
+
+import '../agent/agent/http/types.dart';
+import '../agent/auth.dart';
+import '../agent/cbor.dart';
+import '../agent/request_id.dart';
+import '../agent/types.dart';
+import '../principal/principal.dart';
+import '../utils/extension.dart';
+import '../utils/u8a.dart';
 
 final authDelegationDomainSeparator =
     '\x1Aic-request-auth-delegation'.plainToU8a();

--- a/packages/agent_dart_base/lib/identity/der.dart
+++ b/packages/agent_dart_base/lib/identity/der.dart
@@ -1,7 +1,8 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/utils/extension.dart';
 import 'package:tuple/tuple.dart';
+
+import '../utils/extension.dart';
 
 bool bufEquals(ByteBuffer b1, ByteBuffer b2) {
   if (b1.lengthInBytes != b2.lengthInBytes) return false;

--- a/packages/agent_dart_base/lib/identity/ed25519.dart
+++ b/packages/agent_dart_base/lib/identity/ed25519.dart
@@ -1,10 +1,15 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/auth.dart' as auth;
-import 'package:agent_dart_base/agent_dart_base.dart';
+import 'package:agent_dart_ffi/agent_dart_ffi.dart';
 import 'package:crypto/crypto.dart';
 import 'package:meta/meta.dart';
+
+import '../agent/auth.dart' as auth;
+import '../agent/crypto/random.dart';
+import '../agent/types.dart';
+import '../utils/extension.dart';
+import 'der.dart';
 
 @immutable
 class Ed25519KeyPair extends auth.KeyPair {

--- a/packages/agent_dart_base/lib/identity/identity.dart
+++ b/packages/agent_dart_base/lib/identity/identity.dart
@@ -1,4 +1,4 @@
-export 'delegation.dart' hide Delegation;
+export 'delegation.dart';
 export 'der.dart';
 export 'ed25519.dart';
 export 'p256.dart';

--- a/packages/agent_dart_base/lib/identity/p256.dart
+++ b/packages/agent_dart_base/lib/identity/p256.dart
@@ -1,7 +1,13 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent_dart_base.dart';
+import 'package:agent_dart_ffi/agent_dart_ffi.dart';
+
+import '../agent/auth.dart';
+import '../agent/types.dart';
+import '../utils/extension.dart';
+import '../wallet/keysmith.dart';
+import 'der.dart';
 
 class P256KeyPair extends KeyPair {
   const P256KeyPair({required super.publicKey, required super.secretKey});

--- a/packages/agent_dart_base/lib/identity/schnorr.dart
+++ b/packages/agent_dart_base/lib/identity/schnorr.dart
@@ -1,7 +1,13 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent_dart_base.dart';
+import 'package:agent_dart_ffi/agent_dart_ffi.dart';
+
+import '../agent/auth.dart';
+import '../agent/types.dart';
+import '../utils/extension.dart';
+import '../wallet/keysmith.dart';
+import 'der.dart';
 
 class SchnorrKeyPair extends KeyPair {
   const SchnorrKeyPair({required super.publicKey, required super.secretKey});

--- a/packages/agent_dart_base/lib/identity/secp256k1.dart
+++ b/packages/agent_dart_base/lib/identity/secp256k1.dart
@@ -1,17 +1,21 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent_dart_base.dart';
-
+import 'package:agent_dart_ffi/agent_dart_ffi.dart';
 import 'package:pointycastle/api.dart' as p_api;
 import 'package:pointycastle/digests/sha256.dart';
-
 import 'package:pointycastle/ecc/api.dart';
 import 'package:pointycastle/macs/hmac.dart';
 import 'package:pointycastle/signers/ecdsa_signer.dart';
-
 // ignore: implementation_imports
 import 'package:pointycastle/src/utils.dart' as p_utils;
+
+import '../agent/auth.dart';
+import '../agent/types.dart';
+import '../utils/extension.dart';
+import '../utils/u8a.dart';
+import '../wallet/keysmith.dart';
+import 'der.dart';
 
 BigInt _bytesToUnsignedInt(Uint8List bytes) {
   return p_utils.decodeBigIntWithSign(1, bytes);

--- a/packages/agent_dart_base/lib/principal/principal.dart
+++ b/packages/agent_dart_base/lib/principal/principal.dart
@@ -8,6 +8,8 @@ import 'utils/sha224.dart';
 
 export 'utils/utils.dart';
 
+enum IdentifierType { accountIdentifier, principal }
+
 const _suffixSelfAuthenticating = 2;
 const _suffixAnonymous = 4;
 const _maxLengthInBytes = 29;

--- a/packages/agent_dart_base/lib/principal/utils/sha224.dart
+++ b/packages/agent_dart_base/lib/principal/utils/sha224.dart
@@ -1,10 +1,11 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/utils/number.dart';
 import 'package:crypto/crypto.dart';
 
 // ignore: implementation_imports
 import 'package:crypto/src/digest_sink.dart';
+
+import '../../utils/number.dart';
 
 Uint8List sha224Hash(ByteBuffer buf) {
   return SHA224().update(buf.asUint8List()).toUint8List();

--- a/packages/agent_dart_base/lib/principal/utils/sha256.dart
+++ b/packages/agent_dart_base/lib/principal/utils/sha256.dart
@@ -1,10 +1,11 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/utils/number.dart';
 import 'package:crypto/crypto.dart';
 
 // ignore: implementation_imports
 import 'package:crypto/src/digest_sink.dart';
+
+import '../../utils/number.dart';
 
 Uint8List sha256Hash(ByteBuffer buf) {
   return SHA256().update(buf.asUint8List()).toUint8List();

--- a/packages/agent_dart_base/lib/utils/bech32.dart
+++ b/packages/agent_dart_base/lib/utils/bech32.dart
@@ -1,8 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/wallet/hashing.dart';
-
+import '../../wallet/hashing.dart';
 import 'extension.dart';
 
 class TooShortHrp implements Exception {

--- a/packages/agent_dart_base/lib/utils/extension.dart
+++ b/packages/agent_dart_base/lib/utils/extension.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:typed_data/typed_data.dart';
 
+import '../principal/principal.dart' show IdentifierType, Principal;
 import 'bn.dart' as bn_util;
 import 'hex.dart' as hex_util;
 import 'is.dart' as is_util;
@@ -27,6 +28,18 @@ extension AgentStringExtension on String {
       hex_util.hexToBn(this, endian: endian, isNegative: isNegative);
 
   String camelCase() => string_util.stringCamelCase(this);
+
+  IdentifierType? get identifierType {
+    if (is_util.isAccountId(this)) {
+      return IdentifierType.accountIdentifier;
+    }
+    try {
+      Principal.fromText(this);
+      return IdentifierType.principal;
+    } catch (_) {
+      return null;
+    }
+  }
 }
 
 extension AgentU8aExtension on Uint8List {

--- a/packages/agent_dart_base/lib/utils/is.dart
+++ b/packages/agent_dart_base/lib/utils/is.dart
@@ -1,9 +1,9 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/utils/extension.dart';
 import 'package:validators/validators.dart' as validators;
 
 import '../principal/utils/get_crc.dart';
+import 'extension.dart';
 import 'u8a.dart';
 
 bool isAscii(dynamic value) {

--- a/packages/agent_dart_base/lib/wallet/hashing.dart
+++ b/packages/agent_dart_base/lib/wallet/hashing.dart
@@ -1,12 +1,13 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/principal/utils/get_crc.dart';
-import 'package:agent_dart_base/utils/extension.dart';
-import 'package:agent_dart_base/utils/u8a.dart';
 import 'package:crypto/crypto.dart';
 // ignore: implementation_imports
 import 'package:crypto/src/digest_sink.dart';
 import 'package:typed_data/typed_buffers.dart';
+
+import '../principal/utils/get_crc.dart';
+import '../utils/extension.dart';
+import '../utils/u8a.dart';
 
 Uint8List sha256Chunks(List<dynamic> chunks) {
   final ds = DigestSink();

--- a/packages/agent_dart_base/lib/wallet/keysmith.dart
+++ b/packages/agent_dart_base/lib/wallet/keysmith.dart
@@ -1,13 +1,14 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/identity/identity.dart';
-import 'package:agent_dart_base/principal/principal.dart';
-import 'package:agent_dart_base/utils/extension.dart';
 import 'package:agent_dart_ffi/agent_dart_ffi.dart';
 import 'package:bip32/bip32.dart' as bip32;
 import 'package:bip39/bip39.dart' as bip39;
 import 'package:pointycastle/ecc/api.dart';
 import 'package:pointycastle/ecc/curves/secp256k1.dart';
+
+import '../../identity/identity.dart';
+import '../../principal/principal.dart';
+import '../../utils/extension.dart';
 
 final ECCurve_secp256k1 secp256k1Params = ECCurve_secp256k1();
 

--- a/packages/agent_dart_base/lib/wallet/ledger.dart
+++ b/packages/agent_dart_base/lib/wallet/ledger.dart
@@ -1,6 +1,15 @@
 // ignore_for_file: non_constant_identifier_names
-import 'package:agent_dart_base/agent_dart_base.dart';
+
 import 'package:pinenacl/ed25519.dart';
+
+import '../agent/agent/factory.dart';
+import '../agent/auth.dart';
+import '../agent/crypto/random.dart';
+import '../candid/idl.dart';
+import '../principal/principal.dart';
+import '../utils/extension.dart';
+import '../utils/is.dart';
+import '../utils/u8a.dart';
 
 const _accountIdentifier = IDL.Text;
 

--- a/packages/agent_dart_base/lib/wallet/ledger.dart
+++ b/packages/agent_dart_base/lib/wallet/ledger.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: non_constant_identifier_names
 
-import 'package:pinenacl/ed25519.dart';
+import 'dart:typed_data';
 
 import '../agent/agent/factory.dart';
 import '../agent/auth.dart';

--- a/packages/agent_dart_base/lib/wallet/pem.dart
+++ b/packages/agent_dart_base/lib/wallet/pem.dart
@@ -2,9 +2,12 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:pointycastle/asn1/object_identifiers.dart';
 import 'package:pointycastle/pointycastle.dart';
+
+import '../identity/ed25519.dart';
+import '../identity/secp256k1.dart';
+import '../utils/extension.dart';
 
 const String _beginECPrivateKey = '-----BEGIN EC PRIVATE KEY-----';
 const String _beginPrivateKey = '-----BEGIN PRIVATE KEY-----';

--- a/packages/agent_dart_base/lib/wallet/phrase.dart
+++ b/packages/agent_dart_base/lib/wallet/phrase.dart
@@ -1,7 +1,8 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/wallet/keysmith.dart';
 import 'package:agent_dart_ffi/agent_dart_ffi.dart';
+
+import 'keysmith.dart';
 
 class Phrase {
   Phrase(this.mnemonic) : _list = mnemonic.trim().split(' ');

--- a/packages/agent_dart_base/lib/wallet/rosetta.dart
+++ b/packages/agent_dart_base/lib/wallet/rosetta.dart
@@ -2,10 +2,13 @@ import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/agent/http/fetch.dart';
-import 'package:agent_dart_base/agent_dart_base.dart';
-import 'package:agent_dart_base/protobuf/ic_ledger/pb/v1/types.pb.dart';
-
+import '../agent/agent.dart';
+import '../identity/identity.dart';
+import '../principal/principal.dart';
+import '../protobuf/ic_ledger/pb/v1/types.pb.dart';
+import '../utils/extension.dart';
+import 'hashing.dart';
+import 'keysmith.dart';
 import 'types.dart' as rosetta;
 
 // Set useNativeBigInt to true and use BigInt once BigInt is widely supported.
@@ -533,7 +536,7 @@ Future<CombineSignedTransactionResult> ecTransferCombine(
 CombineSignedTransactionResult combine(
   rosetta.ConstructionCombineRequestPart req,
 ) {
-  final signaturesBySigData = <String, rosetta.Signature>{};
+  final signaturesBySigData = <String, rosetta.WalletSignature>{};
   for (final sig in req.signatures) {
     signaturesBySigData.putIfAbsent(sig.signingPayload.hexBytes, () => sig);
   }

--- a/packages/agent_dart_base/lib/wallet/rosetta.dart
+++ b/packages/agent_dart_base/lib/wallet/rosetta.dart
@@ -142,7 +142,7 @@ class RosettaApi {
 
   /// Return the ICP account balance of the specified account.
   /// @param {string} accountAddress The account address to get the ICP balance of.
-  /// @returns {Promise<BigNumber|TransactionError>} The ICP account balance of the specified account, or
+  /// @returns {Promise\<BigNumber|TransactionError\>} The ICP account balance of the specified account, or
   /// a TransactionError for error.
   Future<BigInt> getAccountBalance(accountAddress) async {
     final response = await accountBalanceByAddress(accountAddress);
@@ -150,7 +150,7 @@ class RosettaApi {
   }
 
   /// Return the latest block index.
-  /// @returns {Promise<number>} The latest block index, or a TransactionError for error.
+  /// @returns {Promise\<number\>} The latest block index, or a TransactionError for error.
   Future<int> getLastBlockIndex() async {
     final response = await networkStatus();
     return response.currentBlockIdentifier.index;
@@ -194,7 +194,7 @@ class RosettaApi {
   /// @param maxBlockIndex {number} The block index to start at. If not specified, start at current
   /// block.
   /// @param offset {number} The offset from maxBlockIndex to start returning transactions.
-  /// @returns {Promise<Array<Transaction>|null>} An array of Transaction objects, or a TransactionError
+  /// @returns {Promise\<Array\<Transaction\>|null\>} An array of Transaction objects, or a TransactionError
   /// for error.
   Future<List<RosettaTransaction>> getTransactions(
     int limit,
@@ -226,7 +226,7 @@ class RosettaApi {
   /// Return an array of Transaction objects based on the specified parameters, or an empty array if
   /// none found.
   /// @param {string} accountAddress The account address to get the transactions of.
-  /// @returns {Promise<Array<Transaction>|null>} An array of Transaction objects, or a TransactionError
+  /// @returns {Promise\<Array\<Transaction\>|null\>} An array of Transaction objects, or a TransactionError
   /// for error.
   Future<List<RosettaTransaction>> getTransactionsByAccount(
     String accountAddress,
@@ -259,7 +259,7 @@ class RosettaApi {
   /// Perform the specified http request and return the response data.
   /// @param {string} url The server URL that will be used for the request.
   /// @param {object} data The data to be sent as the request body.
-  /// @returns {Promise<any>} The response body that was provided by the server.
+  /// @returns {Promise\<any\>} The response body that was provided by the server.
   /// @private
   Future<Map<String, dynamic>> request(String url, dynamic data) async {
     final res = await defaultFetch(
@@ -285,7 +285,7 @@ class RosettaApi {
 
   /// Return the /network/list response, containing a list of NetworkIdentifiers that the Rosetta
   /// server supports.
-  /// @returns {Promise<any>} The response body that was provided by the server.
+  /// @returns {Promise\<any\>} The response body that was provided by the server.
   /// @private
   Future<rosetta.NetworkListResponse> networksList() async {
     final result = await request('/network/list', {'metadata': {}});
@@ -309,7 +309,7 @@ class RosettaApi {
   }
 
   /// Return /network/status response, describing the current status of the network.
-  /// @returns {Promise<any>} The response body that was provided by the server.
+  /// @returns {Promise\<any\>} The response body that was provided by the server.
   /// @private
   Future<rosetta.NetworkStatusResponse> networkStatus() async {
     assert(networkIdentifier != null, 'Cannot get networkIdentifier.');
@@ -324,7 +324,7 @@ class RosettaApi {
 
   /// Return the /account/balance response for the specified account.
   /// @param {string} accountAddress The account address to get the balance of.
-  /// @returns {Promise<any>} The response body that was provided by the server.
+  /// @returns {Promise\<any\>} The response body that was provided by the server.
   /// @private
   Future<rosetta.AccountBalanceResponse> accountBalanceByAddress(
     String accountAddress,
@@ -340,7 +340,7 @@ class RosettaApi {
   /// Return the /block response for the block corresponding to the specified block index (i.e.,
   /// block height).
   /// @param {number} blockIndex The index of the block to return.
-  /// @returns {Promise<any>} The response body that was provided by the server.
+  /// @returns {Promise\<any\>} The response body that was provided by the server.
   /// @private
   Future<rosetta.BlockResponse> blockByIndex(int blockIndex) async {
     assert(networkIdentifier != null, 'Cannot get networkIdentifier.');
@@ -354,7 +354,7 @@ class RosettaApi {
   /// Return the /search/transactions response for transactions containing an operation that affects
   /// the specified account.
   /// @param {string} accountAddress The account address to get the transactions of.
-  /// @returns {Promise<any>} The response body that was provided by the server.
+  /// @returns {Promise\<any\>} The response body that was provided by the server.
   /// @private
   Future<rosetta.SearchTransactionsResponse> transactionsByAccount(
     String accountAddress,
@@ -369,7 +369,7 @@ class RosettaApi {
 
   /// Return the /search/transactions response for transactions (only one) with the specified hash.
   /// @param {string} transactionHash The hash of the transaction to return.
-  /// @returns {Promise<any>} The response body that was provided by the server.
+  /// @returns {Promise\<any\>} The response body that was provided by the server.
   /// @private
   Future<rosetta.SearchTransactionsResponse> transactionsByHash(
     String transactionHash,
@@ -384,7 +384,7 @@ class RosettaApi {
 
   /// Return the /search/transactions response for transactions (only one) with the specified hash.
   /// @param {string} transactionHash The hash of the transaction to return.
-  /// @returns {Promise<any>} The response body that was provided by the server.
+  /// @returns {Promise\<any\>} The response body that was provided by the server.
   /// @private
   Future<rosetta.SearchTransactionsResponse> transactions(
     rosetta.SearchTransactionsRequest req,

--- a/packages/agent_dart_base/lib/wallet/signer.dart
+++ b/packages/agent_dart_base/lib/wallet/signer.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/crypto/keystore/key_store.dart';
-import 'package:agent_dart_base/identity/identity.dart';
-import 'package:agent_dart_base/utils/extension.dart';
+import '../agent/crypto/keystore/key_store.dart';
+import '../identity/identity.dart';
+import '../utils/extension.dart';
 
 import 'keysmith.dart';
 import 'rosetta.dart';
@@ -15,7 +15,7 @@ enum SignType { ecdsa, ed25519 }
 
 enum SourceType { ii, plug, keySmith, base }
 
-/// [CurveType] is the type of cryptographic curve associated with a [PublicKey].
+/// [CurveType] is the type of cryptographic curve associated with a [WalletPublicKey].
 ///  * [secp256k1] SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3)
 ///  * [ed25519]  `y (255-bits) || x-sign-bit (1-bit)` - `32 bytes` (https://ed25519.cr.yp.to/ed25519-20110926.pdf)
 ///  * [all] both above.

--- a/packages/agent_dart_base/lib/wallet/types.dart
+++ b/packages/agent_dart_base/lib/wallet/types.dart
@@ -686,12 +686,12 @@ typedef Timestamp = int;
 /// encoded in hex. Note that there is no PrivateKey struct as this is
 /// NEVER the concern of an implementation.
 @immutable
-class PublicKey {
+class WalletPublicKey {
   // "secp256k1" | "secp256r1" | "edwards25519" | "tweedle";
-  const PublicKey(this.hexBytes, this.curveType);
+  const WalletPublicKey(this.hexBytes, this.curveType);
 
-  factory PublicKey.fromJson(Map<String, dynamic> map) {
-    return PublicKey(map['hex_bytes'], map['curve_type']);
+  factory WalletPublicKey.fromJson(Map<String, dynamic> map) {
+    return WalletPublicKey(map['hex_bytes'], map['curve_type']);
   }
 
   /// Hex-encoded public key bytes in the format specified by the [CurveType].
@@ -747,31 +747,31 @@ class SigningPayload {
   }
 }
 
-/// [Signature] contains the payload that was signed, the public keys of the
+/// [WalletSignature] contains the payload that was signed, the public keys of the
 /// key-pairs used to produce the signature, the signature (encoded in hex),
 /// and the SignatureType. PublicKey is often times not known during
 /// construction of the signing payloads but may be needed to
 /// combine signatures properly.
 @immutable
-class Signature {
-  const Signature(
+class WalletSignature {
+  const WalletSignature(
     this.signingPayload,
     this.publicKey,
     this.signatureType,
     this.hexBytes,
   );
 
-  factory Signature.fromJson(Map<String, dynamic> map) {
-    return Signature(
+  factory WalletSignature.fromJson(Map<String, dynamic> map) {
+    return WalletSignature(
       SigningPayload.fromJson(map['signing_payload']),
-      PublicKey.fromJson(map['public_key']),
+      WalletPublicKey.fromJson(map['public_key']),
       map['signature_type'],
       map['hex_bytes'],
     );
   }
 
   final SigningPayload signingPayload;
-  final PublicKey publicKey;
+  final WalletPublicKey publicKey;
 
   /// export type SignatureType =
   ///   | "ecdsa"
@@ -1484,7 +1484,7 @@ class NetworkOptionsResponse {
 /// left purposely unstructured to allow flexibility for implementers.
 /// [options] is not required in the case that there is network-wide metadata
 /// of interest. Optionally, the request can also include an array of
-/// [PublicKey]s associated with the [AccountIdentifiers] returned in
+/// [WalletPublicKey]s associated with the [AccountIdentifiers] returned in
 /// [ConstructionPreprocessResponse].
 @immutable
 class ConstructionMetadataRequest {
@@ -1500,7 +1500,7 @@ class ConstructionMetadataRequest {
       map['options'],
       map['public_keys'] != null
           ? (map['public_keys'] as List)
-              .map((e) => PublicKey.fromJson(e))
+              .map((e) => WalletPublicKey.fromJson(e))
               .toList()
           : null,
     );
@@ -1516,7 +1516,7 @@ class ConstructionMetadataRequest {
   /// to only the subset required.
   final Map<String, dynamic>? options;
 
-  final List<PublicKey>? publicKeys;
+  final List<WalletPublicKey>? publicKeys;
 
   Map<String, dynamic> toJson() {
     return {
@@ -1577,14 +1577,14 @@ class ConstructionDeriveRequest {
   factory ConstructionDeriveRequest.fromJson(Map<String, dynamic> map) {
     return ConstructionDeriveRequest(
       NetworkIdentifier.fromJson(map['network_identifier']),
-      PublicKey.fromJson(map['public_key']),
+      WalletPublicKey.fromJson(map['public_key']),
       map['metadata'],
     );
   }
 
   final NetworkIdentifier networkIdentifier;
 
-  final PublicKey publicKey;
+  final WalletPublicKey publicKey;
   final Map<String, dynamic>? metadata;
 
   Map<String, dynamic> toJson() {
@@ -1692,11 +1692,11 @@ class ConstructionPreprocessRequest {
 /// If it is not necessary to make a request to `/construction/metadata`,
 /// `options` should be omitted.
 ///
-/// Some blockchains require the [PublicKey] of
+/// Some blockchains require the [WalletPublicKey] of
 /// particular [AccountIdentifier]s to construct a valid transaction.
-/// To fetch these [PublicKey]s, populate `required_public_keys` with the
-/// [AccountIdentifier]s associated with the desired [PublicKey]s.
-/// If it is not necessary to retrieve any [PublicKey]s for construction,
+/// To fetch these [WalletPublicKey]s, populate `required_public_keys` with the
+/// [AccountIdentifier]s associated with the desired [WalletPublicKey]s.
+/// If it is not necessary to retrieve any [WalletPublicKey]s for construction,
 /// `required_public_keys` should be omitted.
 @immutable
 class ConstructionPreprocessResponse {
@@ -1733,7 +1733,7 @@ class ConstructionPreprocessResponse {
 /// [ConstructionPayloadsRequest] is the request to `/construction/payloads`.
 /// It contains the network, a slice of operations, and arbitrary metadata
 /// that was returned by the call to `/construction/metadata`.
-/// Optionally, the request can also include an array of [PublicKey]s associated
+/// Optionally, the request can also include an array of [WalletPublicKey]s associated
 /// with the [AccountIdentifier]s returned in [ConstructionPreprocessResponse].
 @immutable
 class ConstructionPayloadsRequest {
@@ -1751,7 +1751,7 @@ class ConstructionPayloadsRequest {
       map['metadata'],
       map['public_keys'] != null
           ? (map['public_keys'] as List)
-              .map((e) => PublicKey.fromJson(e))
+              .map((e) => WalletPublicKey.fromJson(e))
               .toList()
           : null,
     );
@@ -1760,7 +1760,7 @@ class ConstructionPayloadsRequest {
   final NetworkIdentifier networkIdentifier;
   final List<Operation> operations;
   final Map<String, dynamic>? metadata;
-  final List<PublicKey>? publicKeys;
+  final List<WalletPublicKey>? publicKeys;
 
   Map<String, dynamic> toJson() {
     return {
@@ -1824,13 +1824,13 @@ class ConstructionCombineRequest {
     return ConstructionCombineRequest(
       NetworkIdentifier.fromJson(map['network_identifier']),
       map['unsigned_transaction'],
-      (map['signatures'] as List).map((e) => Signature.fromJson(e)).toList(),
+      (map['signatures'] as List).map((e) => WalletSignature.fromJson(e)).toList(),
     );
   }
 
   final NetworkIdentifier networkIdentifier;
   final String unsignedTransaction;
-  final List<Signature> signatures;
+  final List<WalletSignature> signatures;
 
   Map<String, dynamic> toJson() {
     return {
@@ -1855,13 +1855,13 @@ class ConstructionCombineRequestPart {
           ? NetworkIdentifier.fromJson(map['network_identifier'])
           : null,
       map['unsigned_transaction'],
-      (map['signatures'] as List).map((e) => Signature.fromJson(e)).toList(),
+      (map['signatures'] as List).map((e) => WalletSignature.fromJson(e)).toList(),
     );
   }
 
   final NetworkIdentifier? networkIdentifier;
   final String unsignedTransaction;
-  final List<Signature> signatures;
+  final List<WalletSignature> signatures;
 
   Map<String, dynamic> toJson() {
     return {

--- a/packages/agent_dart_base/lib/wallet/wallet.dart
+++ b/packages/agent_dart_base/lib/wallet/wallet.dart
@@ -1,5 +1,6 @@
 export 'hashing.dart';
 export 'keysmith.dart';
+export 'ledger.dart';
 export 'pem.dart';
 export 'phrase.dart';
 export 'rosetta.dart';

--- a/packages/agent_dart_base/pubspec.yaml
+++ b/packages/agent_dart_base/pubspec.yaml
@@ -1,5 +1,5 @@
 name: agent_dart_base
-version: 1.0.0-dev.25
+version: 1.0.0-dev.26
 
 description: The Dart plugin that bridges Rust implementation for agent_dart.
 repository: https://github.com/AstroxNetwork/agent_dart

--- a/packages/agent_dart_base/pubspec.yaml
+++ b/packages/agent_dart_base/pubspec.yaml
@@ -11,25 +11,20 @@ environment:
 dependencies:
   agent_dart_ffi: ^1.0.0-0
 
-  plugin_platform_interface: ^2.0.2
   archive: ^3.6.0
   args: ^2.3.1
-  basic_utils: ^5.7.0
   bip32: ^2.0.0
   bip39: ^1.0.6
-  dart_bs58check: ^3.0.2
   cbor: ^4.1.0
   collection: ^1.16.0
   convert: ^3.0.1
   crypto: ^3.0.2
-  ffi: ^2.0.1
   fixnum: ^1.0.1
   flutter_rust_bridge: '>=2.1.0 <2.2.0'
   http: ^1.0.0
   js: '>=0.6.4 <0.8.0'
   meta: ^1.7.0
   path: ^1.8.1
-  pinenacl: ^0.3.4
   pointycastle: ^3.6.0
   protobuf: ^3.0.0
   recase: ^4.0.0
@@ -43,7 +38,6 @@ dependencies:
 
 dev_dependencies:
   lints: # transparent
-  ffigen: ^11.0.0
   test: ^1.24.0
   build_runner: ^2.4.5
   json_serializable: ^6.7.0

--- a/packages/agent_dart_base/test/agent/cbor.dart
+++ b/packages/agent_dart_base/test/agent/cbor.dart
@@ -1,9 +1,6 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/cbor.dart';
-import 'package:agent_dart_base/agent/types.dart';
-import 'package:agent_dart_base/principal/principal.dart';
-import 'package:agent_dart_base/utils/extension.dart';
+import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:test/test.dart';
 import 'package:typed_data/typed_data.dart';
 

--- a/packages/agent_dart_base/test/agent/certificate.dart
+++ b/packages/agent_dart_base/test/agent/certificate.dart
@@ -209,14 +209,29 @@ void hashTest() {
       ),
       'world'.plainToU8a(useDartEncode: true),
     );
-    expect(lookupPath(['aa'.plainToU8a(useDartEncode: true)], tree), null);
-    expect(lookupPath(['ax'.plainToU8a(useDartEncode: true)], tree), null);
-    expect(lookupPath(['b'.plainToU8a(useDartEncode: true)], tree), null);
-    expect(lookupPath(['bb'.plainToU8a(useDartEncode: true)], tree), null);
+    expect(
+      lookupPath(['aa'.plainToU8a(useDartEncode: true)], tree),
+      equals(null),
+    );
+    expect(
+      lookupPath(['ax'.plainToU8a(useDartEncode: true)], tree),
+      equals(null),
+    );
+    expect(
+      lookupPath(['b'.plainToU8a(useDartEncode: true)], tree),
+      equals(null),
+    );
+    expect(
+      lookupPath(['bb'.plainToU8a(useDartEncode: true)], tree),
+      equals(null),
+    );
     expect(
       lookupPath(['d'.plainToU8a(useDartEncode: true)], tree),
       'morning'.plainToU8a(useDartEncode: true),
     );
-    expect(lookupPath(['e'.plainToU8a(useDartEncode: true)], tree), null);
+    expect(
+      lookupPath(['e'.plainToU8a(useDartEncode: true)], tree),
+      equals(null),
+    );
   });
 }

--- a/packages/agent_dart_base/test/agent/certificate.dart
+++ b/packages/agent_dart_base/test/agent/certificate.dart
@@ -1,8 +1,6 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/cbor.dart';
-import 'package:agent_dart_base/agent/certificate.dart';
-import 'package:agent_dart_base/utils/extension.dart';
+import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:test/test.dart';
 
 Uint8List label(String str) {

--- a/packages/agent_dart_base/test/agent/polling.dart
+++ b/packages/agent_dart_base/test/agent/polling.dart
@@ -1,6 +1,4 @@
-import 'package:agent_dart_base/agent/agent/http/index.dart';
-import 'package:agent_dart_base/agent/polling/polling.dart';
-import 'package:agent_dart_base/principal/principal.dart';
+import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/agent_dart_base/test/agent/request_id.dart
+++ b/packages/agent_dart_base/test/agent/request_id.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
-import 'package:agent_dart_base/agent/request_id.dart';
-import 'package:agent_dart_base/agent/types.dart';
+import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/agent_dart_base/test/agent/utils/bls.dart
+++ b/packages/agent_dart_base/test/agent/utils/bls.dart
@@ -1,5 +1,4 @@
-import 'package:agent_dart_base/agent/bls.dart';
-import 'package:agent_dart_base/utils/extension.dart';
+import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/agent_dart_base/test/agent/utils/hash.dart
+++ b/packages/agent_dart_base/test/agent/utils/hash.dart
@@ -1,6 +1,4 @@
-import 'package:agent_dart_base/agent/utils/hash.dart';
-// ignore: unused_import
-import 'package:agent_dart_base/utils/extension.dart';
+import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/agent_dart_base/test/agent/utils/leb128.dart
+++ b/packages/agent_dart_base/test/agent/utils/leb128.dart
@@ -1,8 +1,6 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/utils/buffer_pipe.dart';
-import 'package:agent_dart_base/agent/utils/leb128.dart';
-import 'package:agent_dart_base/utils/extension.dart';
+import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/agent_dart_base/test/authentication/authentication.dart
+++ b/packages/agent_dart_base/test/authentication/authentication.dart
@@ -1,9 +1,6 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/auth.dart';
-import 'package:agent_dart_base/authentication/authentication.dart';
-import 'package:agent_dart_base/identity/delegation.dart';
-import 'package:agent_dart_base/identity/ed25519.dart';
+import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:test/test.dart';
 
 Future<SignIdentity> createIdentity(int seed) async {

--- a/packages/agent_dart_base/test/identity/delegation.dart
+++ b/packages/agent_dart_base/test/identity/delegation.dart
@@ -1,11 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/agent.dart';
-import 'package:agent_dart_base/identity/delegation.dart';
-import 'package:agent_dart_base/identity/ed25519.dart';
-import 'package:agent_dart_base/principal/principal.dart';
-import 'package:agent_dart_base/utils/extension.dart';
+import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:test/test.dart';
 
 Future<SignIdentity> createIdentity(int seed) {

--- a/packages/agent_dart_base/test/identity/ed25519.dart
+++ b/packages/agent_dart_base/test/identity/ed25519.dart
@@ -1,9 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/agent/types.dart';
-import 'package:agent_dart_base/identity/ed25519.dart';
-import 'package:agent_dart_base/utils/extension.dart';
+import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:test/test.dart';
 
 // import 'package:agent_dart/utils/extension.dart';

--- a/packages/agent_dart_base/test/principal/principal.dart
+++ b/packages/agent_dart_base/test/principal/principal.dart
@@ -1,6 +1,6 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/principal/principal.dart';
+import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:test/test.dart';
 
 import '../test_utils.dart';

--- a/packages/agent_dart_base/test/principal/utils/base32.dart
+++ b/packages/agent_dart_base/test/principal/utils/base32.dart
@@ -1,5 +1,4 @@
-import 'package:agent_dart_base/principal/utils/base32.dart';
-import 'package:agent_dart_base/utils/extension.dart';
+import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/agent_dart_base/test/principal/utils/get_crc.dart
+++ b/packages/agent_dart_base/test/principal/utils/get_crc.dart
@@ -1,6 +1,6 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/principal/utils/get_crc.dart';
+import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/agent_dart_base/test/utils/is.dart
+++ b/packages/agent_dart_base/test/utils/is.dart
@@ -1,9 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/principal/principal.dart';
-import 'package:agent_dart_base/utils/extension.dart';
-import 'package:agent_dart_base/utils/is.dart';
+import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/agent_dart_base/test/utils/utils_test.dart
+++ b/packages/agent_dart_base/test/utils/utils_test.dart
@@ -1,4 +1,4 @@
-import 'package:agent_dart_base/utils/extension.dart';
+import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:test/test.dart';
 
 import 'is.dart' as is_test;

--- a/packages/agent_dart_base/test/wallet/ledger.dart
+++ b/packages/agent_dart_base/test/wallet/ledger.dart
@@ -1,5 +1,4 @@
 import 'package:agent_dart_base/agent_dart_base.dart';
-import 'package:agent_dart_base/wallet/ledger.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/agent_dart_base/test/wallet/rosetta.dart
+++ b/packages/agent_dart_base/test/wallet/rosetta.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 
-import 'package:agent_dart_base/wallet/rosetta.dart';
-import 'package:agent_dart_base/wallet/signer.dart';
+import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/agent_dart_base/test/wallet/signer.dart
+++ b/packages/agent_dart_base/test/wallet/signer.dart
@@ -14,22 +14,30 @@ void main() {
     stopwatch
       ..reset()
       ..start();
-    final acc2 = await ICPSigner.fromPhrase(mne2, curveType: CurveType.all);
+    final acc2 = await ICPSigner.fromPhrase(
+      mne2,
+      curveType: CurveType.all,
+    );
     stopwatch.stop();
     final allCurvesDuration = stopwatch.elapsed;
 
     stopwatch
       ..reset()
       ..start();
-    final acc21 = await ICPSigner.fromPhrase(mne2);
+    final acc21 = await ICPSigner.fromPhrase(
+      mne2,
+      curveType: CurveType.ed25519,
+    );
     stopwatch.stop();
     final acc21TimePeriod = stopwatch.elapsed;
 
     stopwatch
       ..reset()
       ..start();
-    final acc22 =
-        await ICPSigner.fromPhrase(mne2, curveType: CurveType.secp256k1);
+    final acc22 = await ICPSigner.fromPhrase(
+      mne2,
+      curveType: CurveType.secp256k1,
+    );
     stopwatch.stop();
     final acc22TimePeriod = stopwatch.elapsed;
 
@@ -37,8 +45,8 @@ void main() {
     expect(acc22TimePeriod < allCurvesDuration, true);
     expect(acc2.account.identity != null, true);
     expect(acc2.account.ecIdentity != null, true);
-    expect(acc21.account.ecIdentity, null);
-    expect(acc22.account.identity, null);
+    expect(acc21.account.ecIdentity, equals(null));
+    expect(acc22.account.identity, equals(null));
 
     expect(
       acc2.account.ecKeys?.accountId!.toHex(),
@@ -51,8 +59,8 @@ void main() {
 
     await acc2.lock('123');
     expect(acc2.isLocked, true);
-    expect(acc2.account.identity, null);
-    expect(acc2.account.ecKeys, null);
+    expect(acc2.account.identity, equals(null));
+    expect(acc2.account.ecKeys, equals(null));
 
     await acc2.unlock('123');
     expect(acc2.isLocked, false);

--- a/packages/agent_dart_base/test/wallet/signer.dart
+++ b/packages/agent_dart_base/test/wallet/signer.dart
@@ -1,9 +1,6 @@
 import 'dart:convert';
 
-import 'package:agent_dart_base/agent/crypto/index.dart';
-import 'package:agent_dart_base/utils/extension.dart';
-import 'package:agent_dart_base/wallet/phrase.dart';
-import 'package:agent_dart_base/wallet/signer.dart';
+import 'package:agent_dart_base/agent_dart_base.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/agent_dart_ffi/pubspec.yaml
+++ b/packages/agent_dart_ffi/pubspec.yaml
@@ -1,5 +1,5 @@
 name: agent_dart_ffi
-version: 1.0.0-dev.25
+version: 1.0.0-dev.26
 
 description: The FFI plugin that bridges Rust implementation for agent_dart.
 repository: https://github.com/AstroxNetwork/agent_dart


### PR DESCRIPTION
1. Reorg exports/imports so people can directly import `agent_dart_base/agent_dart_base.dart` or `agent_dart/agent_dart.dart` without conflicts as much as possible.
2. Improve test equality checks.
3. Remove unnecessary deps.