### PR TITLE
`Nat` encode improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ that can be found in the LICENSE file. -->
 
 # Changelog
 
+## 1.0.0-dev.31
+
+- Treat parsable big number string as a covariant of the `Nat` class.
+- Allow parsable big number string for `lebEncode` and `slebEncode`.
+
 ## 1.0.0-dev.30
 
 - Make pod shell respect configured profile on Darwin.

--- a/packages/agent_dart/pubspec.yaml
+++ b/packages/agent_dart/pubspec.yaml
@@ -1,5 +1,5 @@
 name: agent_dart
-version: 1.0.0-dev.30
+version: 1.0.0-dev.31
 
 description: |
   An agent library built for Internet Computer,

--- a/packages/agent_dart_base/lib/agent/utils/leb128.dart
+++ b/packages/agent_dart_base/lib/agent/utils/leb128.dart
@@ -22,7 +22,12 @@ List<T> safeRead<T>(BufferPipe<T> pipe, int ref) {
 /// nearest integer.
 /// @param value The number to encode.
 Uint8List lebEncode(dynamic value) {
-  BigInt bn = value is BigInt ? value : BigInt.from(value);
+  BigInt bn = switch (value) {
+    BigInt() => value,
+    num() => BigInt.from(value),
+    String() => BigInt.parse(value),
+    _ => throw ArgumentError('Invalid big number: $value', 'lebEncode'),
+  };
   if (bn < BigInt.zero) {
     throw StateError('Cannot leb-encode negative values.');
   }
@@ -58,9 +63,13 @@ BigInt lebDecode<T>(BufferPipe<T> pipe) {
 /// Encode a number (or bigint) into a Buffer, with support for negative numbers.
 /// The number will be floored to the nearest integer.
 /// @param value The number to encode.
-Uint8List slebEncode(Comparable value) {
-  BigInt bn = value is BigInt ? value : BigInt.from(value as num);
-
+Uint8List slebEncode(dynamic value) {
+  BigInt bn = switch (value) {
+    BigInt() => value,
+    num() => BigInt.from(value),
+    String() => BigInt.parse(value),
+    _ => throw ArgumentError('Invalid big number: $value', 'slebEncode'),
+  };
   final isNeg = bn < BigInt.zero;
   if (isNeg) {
     bn = -bn - BigInt.one;

--- a/packages/agent_dart_base/lib/candid/idl.dart
+++ b/packages/agent_dart_base/lib/candid/idl.dart
@@ -528,7 +528,9 @@ class NatClass extends PrimitiveType {
 
   @override
   bool covariant(x) {
-    return (x is BigInt && x >= BigInt.zero) || (x is int && x >= 0);
+    return (x is BigInt && x >= BigInt.zero) ||
+        (x is int && x >= 0) ||
+        (x is String && BigInt.parse(x) >= BigInt.zero);
   }
 
   @override

--- a/packages/agent_dart_base/lib/wallet/signer.dart
+++ b/packages/agent_dart_base/lib/wallet/signer.dart
@@ -263,14 +263,6 @@ class ICPSigner extends BaseSigner<ICPAccount, ConstructionPayloadsResponse,
           curveType: curveType,
         ))
           ..setSourceType(SourceType.base);
-      default:
-        return (await ICPSigner.fromPhrase(
-          phrase,
-          index: hardened,
-          icPath: icDerivationPath,
-          curveType: curveType,
-        ))
-          ..setSourceType(SourceType.ii);
     }
   }
 

--- a/packages/agent_dart_base/pubspec.yaml
+++ b/packages/agent_dart_base/pubspec.yaml
@@ -1,5 +1,5 @@
 name: agent_dart_base
-version: 1.0.0-dev.30
+version: 1.0.0-dev.31
 
 description: The Dart plugin that bridges Rust implementation for agent_dart.
 repository: https://github.com/AstroxNetwork/agent_dart

--- a/packages/agent_dart_base/test/agent/utils/leb128.dart
+++ b/packages/agent_dart_base/test/agent/utils/leb128.dart
@@ -24,6 +24,7 @@ void leb128Test() {
       lebEncode(BigInt.from(60000000000000000)).toHex(),
       '808098f4e9b5ca6a',
     );
+    expect(lebEncode('1').toHex(), '01');
 
     expect(lebDecode(BufferPipe<int>(Uint8List.fromList([0]))), BigInt.zero);
     expect(lebDecode(BufferPipe<int>(Uint8List.fromList([1]))), BigInt.one);
@@ -59,6 +60,7 @@ void leb128Test() {
       slebEncode(BigInt.parse('60000000000000000')).toHex(),
       '808098f4e9b5caea00',
     );
+    expect(slebEncode('1').toHex(), '01');
 
     expect(
       slebDecode(BufferPipe<int>(Uint8List.fromList([0x7f]))),

--- a/packages/agent_dart_base/test/wallet/signer.dart
+++ b/packages/agent_dart_base/test/wallet/signer.dart
@@ -41,8 +41,9 @@ void main() {
     stopwatch.stop();
     final acc22TimePeriod = stopwatch.elapsed;
 
-    expect(acc21TimePeriod < allCurvesDuration, true);
-    expect(acc22TimePeriod < allCurvesDuration, true);
+    print([allCurvesDuration, acc21TimePeriod, acc22TimePeriod]);
+    expect(acc21TimePeriod <= allCurvesDuration, true);
+    expect(acc22TimePeriod <= allCurvesDuration, true);
     expect(acc2.account.identity != null, true);
     expect(acc2.account.ecIdentity != null, true);
     expect(acc21.account.ecIdentity, equals(null));

--- a/packages/agent_dart_ffi/pubspec.yaml
+++ b/packages/agent_dart_ffi/pubspec.yaml
@@ -1,5 +1,5 @@
 name: agent_dart_ffi
-version: 1.0.0-dev.30
+version: 1.0.0-dev.31
 
 description: The FFI plugin that bridges Rust implementation for agent_dart.
 repository: https://github.com/AstroxNetwork/agent_dart


### PR DESCRIPTION
- Treat parsable big number string as a covariant of the `Nat` class.
- Allow parsable big number string for `lebEncode` and `slebEncode`.