### PR TITLE
docs: add API documentation and guides

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,79 @@
+name: Documentation
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'packages/**/lib/**'
+      - 'packages/**/pubspec.yaml'
+      - 'README.md'
+      - '.github/workflows/docs.yml'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Install root dependencies
+        run: dart pub get
+      - name: Install base package dependencies
+        run: dart pub get
+        working-directory: packages/agent_dart_base
+      - name: Generate base API reference
+        run: dart doc --output ../../site/api/agent_dart_base .
+        working-directory: packages/agent_dart_base
+      - name: Install plugin dependencies
+        run: flutter pub get
+        working-directory: packages/agent_dart
+      - name: Generate plugin API reference
+        run: dart doc --output ../../site/api/agent_dart .
+        working-directory: packages/agent_dart
+      - name: Copy guide docs
+        run: |
+          mkdir -p site/guides
+          cp -R docs/. site/guides/
+          cat > site/index.html <<'HTML'
+          <!doctype html>
+          <html lang="en">
+            <head><meta charset="utf-8"><title>agent_dart docs</title></head>
+            <body>
+              <h1>agent_dart documentation</h1>
+              <ul>
+                <li><a href="guides/">Guides</a></li>
+                <li><a href="api/agent_dart/">agent_dart API reference</a></li>
+                <li><a href="api/agent_dart_base/">agent_dart_base API reference</a></li>
+              </ul>
+            </body>
+          </html>
+          HTML
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -75,8 +75,11 @@ make sure you've done the following setup the build settings.
 
 ### 📖 Documentation
 
+- [Local docs](docs/index.md)
+- [Getting started](docs/getting-started.md)
+- [API overview](docs/api-overview.md)
+- [Generate API reference](docs/generating-api-reference.md)
 - [Reference on pub.dev](https://pub.dev/documentation/agent_dart/latest/)
-- Docs site, WIP...
 
 ### 🔧 Helpers/Tooling
 

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -1,0 +1,42 @@
+# API overview
+
+## Principals
+
+`Principal` represents Internet Computer principals for users, canisters, and other IC entities.
+
+Common operations:
+
+- `Principal.fromText(text)` parses canonical text such as `aaaaa-aa`.
+- `Principal.selfAuthenticating(publicKey)` derives a caller principal from a public key.
+- `principal.toText()` returns canonical textual form.
+- `principal.toAccountId()` derives an ICP ledger account identifier.
+
+## Identities
+
+`Identity` describes anything that can transform outgoing agent requests. `AnonymousIdentity` sends unsigned requests, while `SignIdentity` signs requests and derives a self-authenticating principal.
+
+`Ed25519KeyIdentity` is the main signing identity:
+
+- `Ed25519KeyIdentity.generate(seed)` creates a new identity from a 32-byte seed or random seed.
+- `Ed25519KeyIdentity.fromJSON(json)` restores an exported identity.
+- `identity.sign(blob)` signs request bytes.
+- `identity.getPrincipal()` returns the caller principal.
+
+## HTTP agent
+
+`HttpAgent` implements the low-level IC agent interface. It sends query, update, read-state, and status requests to a replica.
+
+Typical app code uses `AgentFactory`, which creates and configures an `HttpAgent` and actor together.
+
+## Actors
+
+`Actor` and `CanisterActor` turn a Candid `Service` into callable Dart methods.
+
+- `Actor.createActor(service, config)` creates a canister actor.
+- `actor.getFunc(name)` returns an `ActorMethod` for a Candid method.
+- `ActorMethod.call(args)` invokes the method with default options.
+- `ActorMethod.withOptions(options, args)` overrides call configuration for one invocation.
+
+## Wallet and ledger helpers
+
+The wallet package contains typed Candid models and helpers for ICP ledger operations. These models convert between Dart objects and the map/list shapes expected by Candid encoding.

--- a/docs/generating-api-reference.md
+++ b/docs/generating-api-reference.md
@@ -1,0 +1,41 @@
+# Generating API reference
+
+agent_dart uses Dart's standard documentation generator.
+
+From the repository root, bootstrap dependencies first:
+
+```shell
+dart pub get
+cd packages/agent_dart_base && dart pub get
+cd ../agent_dart && flutter pub get
+```
+
+Generate docs for the base package:
+
+```shell
+cd packages/agent_dart_base
+dart doc .
+```
+
+Generate docs for the Flutter plugin package:
+
+```shell
+cd packages/agent_dart
+flutter pub get
+dart doc .
+```
+
+The generated site is written to each package's `doc/api` directory. For released versions, pub.dev also builds and hosts the API reference automatically:
+
+<https://pub.dev/documentation/agent_dart/latest/>
+
+
+## GitHub Pages workflow
+
+This repository also includes `.github/workflows/docs.yml`, which builds the guide pages and generated Dart API reference into a single GitHub Pages artifact. After maintainers enable GitHub Pages for GitHub Actions, pushes to `main` can publish:
+
+- guide pages from `docs/`
+- `agent_dart` API reference
+- `agent_dart_base` API reference
+
+The workflow can also be run manually from the GitHub Actions tab with `workflow_dispatch`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,57 @@
+# Getting started
+
+Add `agent_dart` to your Dart or Flutter application:
+
+```yaml
+dependencies:
+  agent_dart: ^1.0.0-dev.40
+```
+
+Import the package:
+
+```dart
+import 'package:agent_dart/agent_dart.dart';
+```
+
+## Connect to a canister
+
+For most apps, create an `AgentFactory` from a canister ID, replica URL, and Candid service definition:
+
+```dart
+final factory = await AgentFactory.createAgent(
+  canisterId: 'ryjl3-tyaaa-aaaaa-aaaba-cai',
+  url: 'https://icp-api.io',
+  idl: idlFactory,
+  debug: false,
+);
+
+final actor = factory.actor;
+```
+
+Use `debug: true` only when connecting to a local replica. In debug mode the agent fetches a root key from the replica, which is useful locally but should not be enabled for mainnet.
+
+## Anonymous calls
+
+If no identity is supplied, the factory uses `AnonymousIdentity`. Anonymous identities can query public canister methods but cannot sign update calls that require authentication.
+
+```dart
+final anonymous = const AnonymousIdentity();
+final principal = anonymous.getPrincipal();
+```
+
+## Signed calls
+
+Use a signing identity when the canister method needs an authenticated caller:
+
+```dart
+final identity = await Ed25519KeyIdentity.generate(null);
+final factory = await AgentFactory.createAgent(
+  canisterId: canisterIdText,
+  url: 'https://icp-api.io',
+  idl: idlFactory,
+  identity: identity,
+  debug: false,
+);
+```
+
+Persist generated identities carefully. `Ed25519KeyIdentity.toJson()` exports private key material, so store it only in secure storage.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,21 @@
+# agent_dart documentation
+
+agent_dart is a Dart and Flutter client library for building Internet Computer applications. It provides:
+
+- identity and signing primitives for authenticated IC requests
+- principal parsing, formatting, and account identifier helpers
+- an HTTP agent for replica query, update, and read-state calls
+- actor helpers for calling Candid services from Dart
+- wallet and ledger helper models for ICP transfers
+
+## Start here
+
+- [Getting started](getting-started.md) — install the package and create a basic actor.
+- [API overview](api-overview.md) — map the main public APIs to common developer tasks.
+- [Generating API reference](generating-api-reference.md) — build local Dart API docs with `dart doc`.
+
+## API reference
+
+The generated API reference is published by pub.dev for released versions:
+
+<https://pub.dev/documentation/agent_dart/latest/>

--- a/packages/agent_dart_base/lib/agent/actor.dart
+++ b/packages/agent_dart_base/lib/agent/actor.dart
@@ -14,6 +14,7 @@ import 'polling/polling.dart';
 import 'request_id.dart';
 import 'types.dart';
 
+/// Error thrown when an actor query or update call fails.
 class ActorCallError extends AgentFetchError {
   ActorCallError(
     Principal canisterId,
@@ -33,6 +34,7 @@ class ActorCallError extends AgentFetchError {
   }
 }
 
+/// Error thrown when a canister query returns a rejected response.
 class QueryCallRejectedError extends ActorCallError {
   QueryCallRejectedError(
     Principal canisterId,
@@ -52,6 +54,7 @@ class QueryCallRejectedError extends ActorCallError {
         );
 }
 
+/// Error thrown when an update call is rejected by the replica.
 class UpdateCallRejectedError extends ActorCallError {
   UpdateCallRejectedError(
     Principal canisterId,
@@ -70,6 +73,10 @@ class UpdateCallRejectedError extends ActorCallError {
         );
 }
 
+/// Runtime options for a single actor method call.
+///
+/// A [CallConfig] can override the actor's default agent, canister routing,
+/// polling strategy, and synchronous-call behavior for one invocation.
 class CallConfig {
   const CallConfig({
     this.agent,
@@ -79,6 +86,7 @@ class CallConfig {
     this.callSync = true,
   });
 
+  /// Builds a call configuration from a JSON-like map.
   factory CallConfig.fromJson(Map<String, dynamic> map) {
     return CallConfig(
       agent: map['agent'],
@@ -106,6 +114,7 @@ class CallConfig {
   /// Whether to call the endpoint synchronously.
   final bool callSync;
 
+  /// Converts this configuration to a JSON-like map.
   Map<String, dynamic> toJson() {
     return {
       'agent': agent,
@@ -181,6 +190,7 @@ class ActorConfig extends CallConfig {
 //   withOptions(options: CallConfig): (...args: Args) => Promise<Ret>;
 // }
 
+/// Installation modes accepted by the IC management canister.
 enum CanisterInstallMode { install, reinstall, upgrade }
 
 /// Internal metadata for actors. It's an enhanced version of [ActorConfig] with
@@ -194,17 +204,26 @@ class ActorMetadata {
   final ActorConfig? config;
 }
 
+/// Options used when installing WASM code into a canister.
 class FieldOptions {
+  /// Creates install-code field options with a WASM [module].
   const FieldOptions(this.module, {this.mode, this.arg});
 
+  /// Builds field options from a JSON-like map.
   factory FieldOptions.fromJson(Map<String, dynamic> map) {
     return FieldOptions(map['module'], mode: map['mode'], arg: map['arg']);
   }
 
+  /// The WASM module bytes to install.
   final BinaryBlob module;
+
+  /// The install mode, usually one of [CanisterInstallMode]'s names.
   final String? mode;
+
+  /// Optional Candid-encoded initialization or upgrade argument.
   final BinaryBlob? arg;
 
+  /// Converts these options to a JSON-like map.
   Map<String, dynamic> toJson() {
     return {'module': module, 'mode': mode, 'arg': arg};
   }
@@ -232,10 +251,12 @@ class Actor {
     return actor.metadata.service;
   }
 
+  /// Returns the canister ID configured on [actor].
   static Principal canisterIdOf(Actor actor) {
     return Principal.from(actor.metadata.config!.canisterId);
   }
 
+  /// Installs, reinstalls, or upgrades code on a canister via the management canister.
   static Future<void> install(FieldOptions fields, ActorConfig config) async {
     final String mode = fields.mode ?? CanisterInstallMode.install.name;
     // Need to transform the arg into a number array.
@@ -256,6 +277,7 @@ class Actor {
     ]);
   }
 
+  /// Creates a new canister and returns its principal.
   static Future<Principal> createCanister(CallConfig? config) async {
     final canister = getManagementCanister(config ?? const CallConfig());
     final ActorMethod? func = canister.getFunc(
@@ -271,6 +293,7 @@ class Actor {
     return canisterId;
   }
 
+  /// Creates a canister, installs [fields.module], and returns an actor for it.
   static Future<CanisterActor> createAndInstallCanister(
     Service interfaceFactory,
     FieldOptions fields,
@@ -289,10 +312,12 @@ class Actor {
     return createActor(interfaceFactory, newConfig);
   }
 
+  /// Creates an actor constructor bound to a Candid [interfaceFactory].
   static ActorConstructor createActorClass(Service interfaceFactory) {
     return CanisterActor.withService(interfaceFactory);
   }
 
+  /// Creates a canister actor from a Candid service and actor configuration.
   static CanisterActor createActor(
     Service interfaceFactory,
     ActorConfig configuration,
@@ -303,12 +328,14 @@ class Actor {
   static const String metadataSymbol = 'ic-agent-metadata';
 }
 
+/// Factory signature used to create callable actor methods.
 typedef CreateActorMethod = ActorMethod Function(
   Actor actor,
   String methodName,
   Func func,
 );
 
+/// An [Actor] backed by a Candid service definition.
 class CanisterActor extends Actor {
   CanisterActor(
     ActorConfig config,
@@ -327,16 +354,19 @@ class CanisterActor extends Actor {
   // [x: string]: ActorMethod;
   final Map<String, ActorMethod> methodMap = <String, ActorMethod>{};
 
+  /// Returns the actor method named [method], or `null` if it is not defined.
   ActorMethod? getFunc(String method) {
     return methodMap[method];
   }
 
+  /// Creates a [CanisterActor] constructor for [service].
   static CanisterActor Function(ActorConfig config) withService(
     Service service,
   ) =>
       (ActorConfig config) => CanisterActor(config, service);
 }
 
+/// Decodes Candid response bytes into the Dart return value expected by callers.
 dynamic decodeReturnValue(List<CType> types, BinaryBlob msg) {
   final returnValues = IDL.decode(types, msg);
   switch (returnValues.length) {
@@ -349,6 +379,7 @@ dynamic decodeReturnValue(List<CType> types, BinaryBlob msg) {
   }
 }
 
+/// Low-level actor method caller signature.
 typedef MethodCaller = Future Function(CallConfig options, List args);
 
 ActorMethod _createActorMethod(Actor actor, String methodName, Func func) {
@@ -477,11 +508,15 @@ ActorMethod _createActorMethod(Actor actor, String methodName, Func func) {
   return ActorMethod(caller);
 }
 
+/// A callable canister method generated from a Candid function definition.
 class ActorMethod {
+  /// Creates an actor method backed by [caller].
   const ActorMethod(this.caller);
 
+  /// The function that performs the query or update call.
   final MethodCaller caller;
 
+  /// Invokes [caller] with optional per-call options.
   static Future<dynamic> handlerCall(
     MethodCaller caller,
     List<dynamic> args,
@@ -490,10 +525,12 @@ class ActorMethod {
     return caller(withOptions ?? const CallConfig(), args);
   }
 
+  /// Calls the method with default options.
   Future<dynamic> call(List<dynamic>? args) {
     return caller(const CallConfig(), args ?? []);
   }
 
+  /// Calls the method with [withOptions] merged into the actor configuration.
   Future<dynamic> withOptions(
     CallConfig withOptions,
     List<dynamic>? args,
@@ -502,4 +539,5 @@ class ActorMethod {
   }
 }
 
+/// Constructor signature for canister actors.
 typedef ActorConstructor = CanisterActor Function(ActorConfig config);

--- a/packages/agent_dart_base/lib/agent/agent/api.dart
+++ b/packages/agent_dart_base/lib/agent/agent/api.dart
@@ -9,18 +9,29 @@ import '../types.dart';
 /// for the interface spec.
 @immutable
 class ReplicaRejectCode {
+  /// Creates a namespace for replica reject code constants.
   const ReplicaRejectCode._();
 
+  /// System fatal reject code.
   static const sysFatal = 1;
+
+  /// System transient reject code.
   static const sysTransient = 2;
+
+  /// Destination invalid reject code.
   static const destinationInvalid = 3;
+
+  /// Canister reject code.
   static const canisterReject = 4;
+
+  /// Canister error reject code.
   static const canisterError = 5;
 }
 
 /// Options when doing a [Agent.readState] call.
 @immutable
 class ReadStateOptions {
+  /// Creates read-state options for [paths].
   const ReadStateOptions({required this.paths});
 
   /// A list of paths to read the state of.
@@ -30,21 +41,30 @@ class ReadStateOptions {
 /// type QueryResponse = QueryResponseReplied | QueryResponseRejected;
 @immutable
 class QueryResponseStatus {
+  /// Creates a namespace for query response status constants.
   const QueryResponseStatus._();
 
+  /// Query replied successfully.
   static const replied = 'replied';
+
+  /// Query was rejected by the replica or canister.
   static const rejected = 'rejected';
 }
 
+/// Base type for query responses.
 @immutable
 abstract class QueryResponseBase {
+  /// Creates a query response base value.
   const QueryResponseBase({required this.status});
 
+  /// Query response status.
   final String status;
 }
 
+/// Query response containing either a reply or rejection details.
 @immutable
 abstract class QueryResponse extends QueryResponseBase {
+  /// Creates a query response.
   const QueryResponse({
     this.reply,
     this.rejectCode,
@@ -52,36 +72,52 @@ abstract class QueryResponse extends QueryResponseBase {
     required super.status,
   });
 
+  /// Successful reply payload, when available.
   final Reply? reply;
+
+  /// Replica reject code, when rejected.
   final int? rejectCode;
+
+  /// Human-readable rejection message, when rejected.
   final String? rejectMessage;
 }
 
+/// Successful query reply payload.
 @immutable
 class Reply {
+  /// Creates a reply with raw argument bytes.
   const Reply(this.arg);
 
+  /// Candid-encoded reply argument bytes.
   final BinaryBlob? arg;
 }
 
+/// Query response for a successful reply.
 class QueryResponseReplied extends QueryResponseBase {
+  /// Creates a replied query response.
   const QueryResponseReplied({super.status = QueryResponseStatus.replied});
 }
 
+/// Query response for a rejection.
 class QueryResponseRejected extends QueryResponseBase {
+  /// Creates a rejected query response.
   const QueryResponseRejected({
     this.rejectCode,
     this.rejectMessage,
     super.status = QueryResponseStatus.rejected,
   });
 
+  /// Replica reject code.
   final int? rejectCode;
+
+  /// Human-readable rejection message.
   final String? rejectMessage;
 }
 
 /// Options when doing a [Agent.query] call.
 @immutable
 class QueryFields {
+  /// Creates query call fields.
   const QueryFields({required this.methodName, this.arg});
 
   /// The method name to call.
@@ -94,6 +130,7 @@ class QueryFields {
 /// Options when doing a [Agent.call] call.
 @immutable
 class CallOptions {
+  /// Creates update-call options.
   const CallOptions({
     required this.methodName,
     required this.arg,
@@ -115,34 +152,51 @@ class CallOptions {
   final bool callSync;
 }
 
+/// Certificate response returned by read-state calls.
 @immutable
 abstract class ReadStateResponse {
+  /// Creates a read-state response.
   const ReadStateResponse({required this.certificate});
 
+  /// CBOR-encoded certificate bytes.
   final BinaryBlob certificate;
 }
 
+/// Base HTTP response metadata.
 @immutable
 abstract class ResponseBody {
+  /// Creates response metadata.
   const ResponseBody({this.ok, this.status, this.statusText});
 
+  /// Whether the HTTP request succeeded.
   final bool? ok;
+
+  /// HTTP status code.
   final int? status;
+
+  /// HTTP status text.
   final String? statusText;
 }
 
+/// Response returned after submitting an update call.
 @immutable
 abstract class SubmitResponse {
+  /// Creates a submit response.
   const SubmitResponse({this.requestId, this.response});
 
+  /// Request ID for the submitted call.
   final RequestId? requestId;
+
+  /// HTTP response metadata and body.
   final ResponseBody? response;
 
+  /// Converts this response to a JSON-like map.
   Map<String, dynamic> toJson();
 }
 
 /// An Agent able to make calls and queries to a Replica.
 abstract class Agent {
+  /// Root key used to verify certificate responses.
   BinaryBlob? rootKey;
 
   /// Returns the principal ID associated with this agent (by default). It only shows
@@ -161,6 +215,7 @@ abstract class Agent {
     Identity? identity,
   );
 
+  /// Submits an update call request to a canister.
   Future<SubmitResponse> callRequest(
     Principal canisterId,
     CallOptions fields,

--- a/packages/agent_dart_base/lib/agent/agent/factory.dart
+++ b/packages/agent_dart_base/lib/agent/agent/factory.dart
@@ -2,7 +2,13 @@ import '../../candid/idl.dart';
 import '../../principal/principal.dart';
 import '../agent.dart';
 
+/// Convenience factory for creating an [HttpAgent] and [CanisterActor].
+///
+/// `AgentFactory` is the easiest entry point for application developers: pass a
+/// canister ID, replica URL, Candid [Service], and optional [Identity], then use
+/// [actor] to call canister methods.
 class AgentFactory {
+  /// Creates a factory for [canisterId] at [url].
   AgentFactory({
     required String canisterId,
     required String url,
@@ -14,6 +20,7 @@ class AgentFactory {
         _debug = debug ?? true,
         _url = url;
 
+  /// Creates a canister actor for [idl] using an existing [agent].
   static CanisterActor createActor(
     Service idl,
     HttpAgent agent,
@@ -25,6 +32,10 @@ class AgentFactory {
     );
   }
 
+  /// Creates, initializes, and returns an [AgentFactory].
+  ///
+  /// When [debug] is true, the agent fetches a root key from the replica. Use
+  /// that for local replicas, not for IC mainnet.
   static Future<AgentFactory> createAgent({
     required String canisterId,
     required String url,
@@ -44,20 +55,29 @@ class AgentFactory {
     return agentFactory;
   }
 
+  /// The canister principal this factory targets.
   final Principal canisterId;
+
+  /// The identity used by the underlying HTTP agent.
   final Identity identity;
   final bool _debug;
+
+  /// Candid service definition used to build the actor.
   final Service idl;
   final String _url;
 
+  /// Returns the initialized HTTP agent.
   HttpAgent getAgent() => _agent;
   late HttpAgent _agent;
 
+  /// The actor generated from [idl], or `null` until [setActor] is called.
   CanisterActor? get actor => _actor;
   CanisterActor? _actor;
 
+  /// Replica URL used by this factory.
   String get agentUrl => _url;
 
+  /// Initializes the underlying HTTP agent for [url].
   Future<void> initAgent(String url) async {
     _agent = HttpAgent.fromUri(
       Uri.parse(url),
@@ -71,6 +91,7 @@ class AgentFactory {
     );
   }
 
+  /// Creates and stores the canister actor for this factory.
   void setActor() {
     _actor = Actor.createActor(
       idl,

--- a/packages/agent_dart_base/lib/agent/agent/http/fetch.dart
+++ b/packages/agent_dart_base/lib/agent/agent/http/fetch.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 
 import '../../types.dart';
 
+/// Default timeout used by the HTTP transport.
 const defaultTimeout = Duration(seconds: 30);
 
 /// [defaultFetch] is a wrapper of [http.get],
@@ -88,7 +89,9 @@ Future<Map<String, dynamic>> defaultFetch({
   }
 }
 
+/// Normalized response returned by HTTP fetch functions.
 class FetchResponse {
+  /// Creates a normalized fetch response.
   const FetchResponse(
     this.body,
     this.ok,
@@ -97,6 +100,7 @@ class FetchResponse {
     this.arrayBuffer,
   );
 
+  /// Creates a response from a JSON-like map.
   factory FetchResponse.fromJson(Map<String, dynamic> map) {
     return FetchResponse(
       map['body'],
@@ -107,12 +111,22 @@ class FetchResponse {
     );
   }
 
+  /// Response body as text.
   final String body;
+
+  /// Whether the HTTP status code represents success.
   final bool ok;
+
+  /// HTTP status code.
   final int statusCode;
+
+  /// HTTP status text.
   final String statusText;
+
+  /// Response body as raw bytes.
   final Uint8List arrayBuffer;
 
+  /// Converts this response to a JSON-like map.
   Map<String, dynamic> toJson() {
     return {
       'body': body,

--- a/packages/agent_dart_base/lib/agent/agent/http/index.dart
+++ b/packages/agent_dart_base/lib/agent/agent/http/index.dart
@@ -16,8 +16,13 @@ import 'fetch.dart';
 import 'transform.dart';
 import 'types.dart';
 
+/// Encodes a string as base64 for HTTP Basic authentication headers.
 const btoa = base64Encode;
 
+/// Runs [action] with simple linear backoff retries.
+///
+/// [retryTimes] is the maximum number of attempts and
+/// [retryIntervalMills] is multiplied by the attempt number before each retry.
 Future<T> withRetry<T>(
   FutureOr<T> Function() action, {
   int retryTimes = 3,
@@ -47,21 +52,28 @@ const defaultExpireInDuration = Duration(minutes: defaultExpireInMinutes);
 const _defaultIngressExpiryDeltaInMilliseconds =
     defaultExpireInMinutes * 60 * 1000;
 
-/// Root public key for the IC, encoded as hex
+/// Root public key for the IC, encoded as hex.
 const _icRootKey = '308182301d060d2b0601040182dc7c0503010201060c2b0601040182dc7'
     'c05030201036100814c0e6ec71fab583b08bd81373c255c3c371b2e84863c98a4f1e08b742'
     '35d14fb5d9c0cd546d9685f913a0c0b2cc5341583bf4b4392e467db96d65b9bb4cb717112f'
     '8472e0d5a4d14505ffd7484b01291091c5f87b98883463f98091a0baaae';
 
+/// HTTP Basic authentication credentials used by [HttpAgent].
 @immutable
 abstract class Credentials {
+  /// Creates credentials from an optional user [name] and [password].
   const Credentials({this.name, this.password});
 
+  /// Username for Basic authentication.
   final String? name;
+
+  /// Password for Basic authentication.
   final String? password;
 }
 
+/// Configuration used to create an [HttpAgent].
 class HttpAgentOptions {
+  /// Creates HTTP agent options.
   const HttpAgentOptions({
     this.source,
     this.fetch,
@@ -70,30 +82,34 @@ class HttpAgentOptions {
     this.credentials,
   });
 
-  // Another HttpAgent to inherit configuration (pipeline and fetch) of.
-  // This is only used at construction.
+  /// Another [HttpAgent] to inherit pipeline and fetch configuration from.
+  ///
+  /// This is only used during construction.
   final HttpAgent? source;
 
-  // A surrogate to the global fetch function. Useful for testing.
+  /// A surrogate fetch hook. Useful for tests and custom transports.
   final void Function()? fetch;
 
-  // The host to use for the client. By default, uses the same host as
-  // the current page.
+  /// Replica host used by the client.
   final String? host;
 
-  // The principal used to send messages. This cannot be empty at the request
-  // time (will throw).
+  /// Identity used to sign requests. Defaults to [AnonymousIdentity].
   final Identity? identity;
 
+  /// Optional Basic authentication credentials.
   final Credentials? credentials;
 }
 
+/// Default HTTP agent options.
 class DefaultHttpAgentOption extends HttpAgentOptions {
+  /// Creates default HTTP agent options.
   const DefaultHttpAgentOption();
 }
 
+/// Shared default HTTP agent options instance.
 const defaultHttpAgentOption = DefaultHttpAgentOption();
 
+/// Transport function used by [HttpAgent] to perform HTTP requests.
 typedef FetchFunction<T> = Future<T> Function({
   required String endpoint,
   String? host,
@@ -102,16 +118,17 @@ typedef FetchFunction<T> = Future<T> Function({
   dynamic body,
 });
 
-// A HTTP agent allows users to interact with a client of the internet computer
-// using the available methods. It exposes an API that closely follows the
-// public view of the internet computer, and is not intended to be exposed
-// directly to the majority of users due to its low-level interface.
-//
-// There is a pipeline to apply transformations to the request before sending
-// it to the client. This is to decouple signature, nonce generation and
-// other computations so that this class can stay as simple as possible while
-// allowing extensions.
+/// Low-level HTTP implementation of [Agent].
+///
+/// `HttpAgent` talks to Internet Computer replica endpoints for status, query,
+/// update, and read-state calls. Most applications should create actors through
+/// [AgentFactory] or [Actor] helpers instead of calling this class directly.
+///
+/// Requests pass through a transform pipeline before they are signed and sent,
+/// which keeps signing, nonce generation, and other request decoration separate
+/// from transport logic.
 class HttpAgent implements Agent {
+  /// Creates an HTTP agent.
   HttpAgent({
     HttpAgentOptions? options,
     this.defaultProtocol = 'https',
@@ -158,6 +175,7 @@ class HttpAgent implements Agent {
     }
   }
 
+  /// Creates an HTTP agent using protocol, host, and port from [uri].
   factory HttpAgent.fromUri(Uri uri, {HttpAgentOptions? options}) {
     return HttpAgent(
       defaultHost: uri.host,
@@ -169,8 +187,13 @@ class HttpAgent implements Agent {
 
   List<HttpAgentRequestTransformFn> _pipeline = [];
 
+  /// Protocol used when [HttpAgentOptions.host] is not fully specified.
   final String defaultProtocol;
+
+  /// Host used when no host option is supplied.
   final String defaultHost;
+
+  /// Port used when no host option is supplied.
   final int defaultPort;
 
   late Identity? _identity;
@@ -184,28 +207,37 @@ class HttpAgent implements Agent {
   @override
   BinaryBlob? rootKey = blobFromHex(_icRootKey);
 
+  /// The identity currently attached to the agent.
   Identity? get identity => _identity;
 
+  /// Replaces the request transform pipeline.
   void setPipeline(List<HttpAgentRequestTransformFn> pl) {
     _pipeline = pl;
   }
 
+  /// Sets the identity used for requests that do not supply one explicitly.
   void setIdentity(Identity? id) {
     _identity = id;
   }
 
+  /// Sets the replica host URL.
   void setHost(String? host) {
     _host = host;
   }
 
+  /// Sets the Basic authentication credential string.
   void setCredentials(String? cred) {
     _credentials = cred;
   }
 
+  /// Sets the transport function used by this agent.
   void setFetch(FetchFunction<Map<String, dynamic>>? fetch) {
     _fetch = fetch ?? _defaultFetch;
   }
 
+  /// Adds a request transform to the pipeline.
+  ///
+  /// Higher-priority transforms run earlier.
   void addTransform(HttpAgentRequestTransformFn fn, [int? priority]) {
     // Keep the pipeline sorted at all time, by priority.
     priority ??= fn.priority ?? 0;
@@ -478,7 +510,9 @@ class HttpAgent implements Agent {
   }
 }
 
+/// Read-state HTTP request wrapper.
 class HttpAgentReadStateRequest extends HttpAgentQueryRequest {
+  /// Creates a read-state request wrapper.
   const HttpAgentReadStateRequest({
     required super.request,
     required super.body,
@@ -486,6 +520,8 @@ class HttpAgentReadStateRequest extends HttpAgentQueryRequest {
   });
 }
 
+/// Read-state response containing a replica certificate.
 class ReadStateResponseResult extends ReadStateResponse {
+  /// Creates a read-state response result.
   const ReadStateResponseResult({required super.certificate});
 }

--- a/packages/agent_dart_base/lib/agent/agent/http/transform.dart
+++ b/packages/agent_dart_base/lib/agent/agent/http/transform.dart
@@ -14,7 +14,9 @@ const _kIsWeb = bool.hasEnvironment('dart.library.js_util')
     ? bool.fromEnvironment('dart.library.js_util')
     : identical(0, 0.0);
 
+/// Ingress expiry timestamp encoded for replica requests.
 class Expiry extends ToCborable {
+  /// Creates an expiry [deltaInMSec] milliseconds from now, minus replica drift.
   Expiry(
     int deltaInMSec,
   ) : _value = (BigInt.from(DateTime.now().millisecondsSinceEpoch) +
@@ -24,8 +26,10 @@ class Expiry extends ToCborable {
 
   final BigInt _value;
 
+  /// Expiry timestamp in nanoseconds.
   BigInt get value => _value;
 
+  /// Returns the LEB128-encoded expiry hash value.
   Uint8List toHash() {
     return lebEncode(_value);
   }
@@ -43,6 +47,7 @@ class Expiry extends ToCborable {
   }
 }
 
+/// Creates a transform that adds a nonce to submit calls.
 HttpAgentRequestTransformFnCall makeNonceTransform([
   NonceFunc nonceFn = makeNonce,
 ]) {
@@ -56,4 +61,5 @@ HttpAgentRequestTransformFnCall makeNonceTransform([
   };
 }
 
+/// Function that creates request nonce bytes.
 typedef NonceFunc = Nonce Function();

--- a/packages/agent_dart_base/lib/agent/agent/http/types.dart
+++ b/packages/agent_dart_base/lib/agent/agent/http/types.dart
@@ -9,6 +9,7 @@ import '../../types.dart';
 import '../api.dart';
 import 'transform.dart';
 
+/// Replica read request type constants.
 class ReadRequestType {
   const ReadRequestType._();
 
@@ -16,12 +17,14 @@ class ReadRequestType {
   static const readState = 'read_state';
 }
 
+/// Replica submit request type constants.
 class SubmitRequestType {
   const SubmitRequestType._();
 
   static const call = 'call';
 }
 
+/// Replica endpoint path identifiers used by HTTP agent requests.
 class Endpoint {
   const Endpoint._();
 
@@ -30,25 +33,37 @@ class Endpoint {
   static const call = 'call';
 }
 
+/// Interface for values that can be serialized into agent request JSON maps.
 mixin WithToJson {
+  /// Converts this value to a JSON-like map.
   Map<String, dynamic> toJson();
 }
 
+/// Base request value for agent HTTP messages.
 abstract class BaseRequest with WithToJson {
+  /// Creates a base request.
   const BaseRequest();
 }
 
+/// Request body for `/read_state` calls.
 class ReadStateRequest extends BaseRequest {
+  /// Creates a read-state request body.
   const ReadStateRequest({
     this.paths,
     this.sender,
     this.ingressExpiry,
   });
 
+  /// Certificate paths to read.
   final List<List<BinaryBlob>>? paths;
+
+  /// Principal or raw bytes for the request sender.
   final Object? sender; //: Uint8Array | Principal;
+
+  /// Ingress expiry timestamp.
   final Expiry? ingressExpiry;
 
+  /// Replica request type.
   String get requestType => ReadRequestType.readState;
 
   @override
@@ -62,7 +77,9 @@ class ReadStateRequest extends BaseRequest {
   }
 }
 
+/// Request body for update calls.
 class CallRequest extends ReadStateRequest {
+  /// Creates an update-call request body.
   CallRequest({
     required this.canisterId,
     required this.methodName,
@@ -72,9 +89,16 @@ class CallRequest extends ReadStateRequest {
     super.ingressExpiry,
   });
 
+  /// Target canister principal.
   final Principal canisterId;
+
+  /// Canister method name.
   final String methodName;
+
+  /// Candid-encoded argument bytes.
   final BinaryBlob arg;
+
+  /// Optional request nonce.
   dynamic nonce;
 
   @override
@@ -94,7 +118,9 @@ class CallRequest extends ReadStateRequest {
   }
 }
 
+/// Request body for canister query calls.
 class QueryRequest extends BaseRequest {
+  /// Creates a query request body.
   const QueryRequest({
     required this.canisterId,
     required this.methodName,
@@ -103,12 +129,22 @@ class QueryRequest extends BaseRequest {
     required this.ingressExpiry,
   });
 
+  /// Target canister principal.
   final Principal canisterId;
+
+  /// Canister method name.
   final String methodName;
+
+  /// Candid-encoded argument bytes.
   final BinaryBlob arg;
+
+  /// Principal or raw bytes for the request sender.
   final dynamic sender; //: Uint8Array | Principal;
+
+  /// Ingress expiry timestamp.
   final Expiry ingressExpiry;
 
+  /// Replica request type.
   String get requestType => ReadRequestType.typeQuery;
 
   @override
@@ -124,18 +160,26 @@ class QueryRequest extends BaseRequest {
   }
 }
 
+/// Alias for read request bodies.
 typedef ReadRequest = ReadStateRequest;
 
+/// HTTP request wrapper used by the agent transform pipeline.
 @immutable
 abstract class HttpAgentBaseRequest<T extends WithToJson> extends BaseRequest {
+  /// Creates an HTTP agent request wrapper.
   const HttpAgentBaseRequest({
     required this.request,
     required this.body,
     this.endpoint,
   });
 
+  /// HTTP request metadata such as method and headers.
   final Map<String, dynamic> request;
+
+  /// Request body payload.
   final T body;
+
+  /// Agent endpoint identifier.
   final String? endpoint;
 
   @override
@@ -148,9 +192,11 @@ abstract class HttpAgentBaseRequest<T extends WithToJson> extends BaseRequest {
   }
 }
 
+/// HTTP wrapper for submit/update requests.
 @immutable
 abstract class HttpAgentSubmitRequest
     extends HttpAgentBaseRequest<CallRequest> {
+  /// Creates a submit request wrapper.
   const HttpAgentSubmitRequest({
     required super.request,
     required super.body,
@@ -158,7 +204,9 @@ abstract class HttpAgentSubmitRequest
   });
 }
 
+/// HTTP wrapper for canister update-call requests.
 class HttpAgentCallRequest extends HttpAgentSubmitRequest {
+  /// Creates a call request wrapper.
   const HttpAgentCallRequest({
     required super.request,
     required super.body,
@@ -166,7 +214,9 @@ class HttpAgentCallRequest extends HttpAgentSubmitRequest {
   });
 }
 
+/// HTTP wrapper for query and read-state requests.
 class HttpAgentQueryRequest extends HttpAgentBaseRequest<BaseRequest> {
+  /// Creates a query request wrapper.
   const HttpAgentQueryRequest({
     required super.request,
     required super.body,
@@ -174,41 +224,59 @@ class HttpAgentQueryRequest extends HttpAgentBaseRequest<BaseRequest> {
   });
 }
 
+/// Unsigned envelope content.
 @immutable
 abstract class UnSigned<T> {
+  /// Creates an unsigned envelope.
   const UnSigned({required this.content});
 
+  /// Envelope payload.
   final T content;
 }
 
+/// Signed envelope content with sender key and signature bytes.
 @immutable
 abstract class Signed<T> extends UnSigned<T> {
+  /// Creates a signed envelope.
   const Signed({
     required super.content,
     required this.senderPublicKey,
     required this.senderSignature,
   });
 
+  /// Sender public key bytes.
   final BinaryBlob senderPublicKey;
+
+  /// Sender signature bytes.
   final BinaryBlob senderSignature;
 }
 
+/// Agent request envelope type.
 typedef Envelope<T> = UnSigned<T>;
 
+/// Agent request type used by transform functions.
 typedef HttpAgentRequest = HttpAgentBaseRequest;
 
+/// Request transform function with an optional priority.
 class HttpAgentRequestTransformFn {
+  /// Creates a request transform.
   HttpAgentRequestTransformFn({required this.call, this.priority});
 
+  /// Transform callback.
   final HttpAgentRequestTransformFnCall call;
+
+  /// Transform priority. Higher-priority transforms run earlier.
   int? priority;
 }
 
+/// Signature for request transform callbacks.
 typedef HttpAgentRequestTransformFnCall = Future<HttpAgentRequest?> Function(
   HttpAgentRequest args,
 );
 
+/// HTTP response body returned by the transport layer.
 class HttpResponseBody extends ResponseBody {
+  /// Creates an HTTP response body.
   const HttpResponseBody({
     super.ok,
     super.status,
@@ -217,6 +285,7 @@ class HttpResponseBody extends ResponseBody {
     this.arrayBuffer,
   });
 
+  /// Creates an HTTP response body from a JSON-like map.
   factory HttpResponseBody.fromJson(Map<String, dynamic> map) {
     return HttpResponseBody(
       arrayBuffer: map['arrayBuffer'],
@@ -227,7 +296,10 @@ class HttpResponseBody extends ResponseBody {
     );
   }
 
+  /// Response body as text, when available.
   final String? body;
+
+  /// Response body as raw bytes, when available.
   final Uint8List? arrayBuffer;
 
   @override
@@ -235,6 +307,7 @@ class HttpResponseBody extends ResponseBody {
     return jsonEncode(toJson());
   }
 
+  /// Converts this response to a JSON-like map.
   Map<String, dynamic> toJson() {
     return {
       'ok': ok,
@@ -246,7 +319,9 @@ class HttpResponseBody extends ResponseBody {
   }
 }
 
+/// Submit response returned by update-call requests.
 class CallResponseBody extends SubmitResponse {
+  /// Creates a call response body.
   CallResponseBody({
     bool? ok,
     int? status,
@@ -264,6 +339,7 @@ class CallResponseBody extends SubmitResponse {
           ),
         );
 
+  /// Creates a call response body from a JSON-like map.
   factory CallResponseBody.fromJson(Map<String, dynamic> map) {
     return CallResponseBody(
       arrayBuffer: map['arrayBuffer'],
@@ -289,7 +365,9 @@ class CallResponseBody extends SubmitResponse {
   }
 }
 
+/// Query response decoded from replica CBOR payloads.
 class QueryResponseWithStatus extends QueryResponse {
+  /// Creates a query response with status.
   const QueryResponseWithStatus({
     super.reply,
     super.rejectCode,
@@ -297,6 +375,7 @@ class QueryResponseWithStatus extends QueryResponse {
     required super.status,
   });
 
+  /// Creates a query response from a decoded CBOR map.
   factory QueryResponseWithStatus.fromJson(Map map) {
     Reply? reply;
     if (map['reply'] != null) {
@@ -314,6 +393,7 @@ class QueryResponseWithStatus extends QueryResponse {
     );
   }
 
+  /// Converts this query response to a JSON-like map.
   Map<String, dynamic> toJson() {
     return {
       'status': status,

--- a/packages/agent_dart_base/lib/agent/agent/proxy.dart
+++ b/packages/agent_dart_base/lib/agent/agent/proxy.dart
@@ -9,7 +9,9 @@ import '../auth.dart';
 import '../types.dart';
 import 'api.dart';
 
+/// Wire message type constants for proxy agent communication.
 class ProxyMessageKind {
+  /// Creates a namespace for proxy message kind constants.
   const ProxyMessageKind._();
 
   static const error = 'err';
@@ -26,14 +28,18 @@ class ProxyMessageKind {
 }
 
 @immutable
+/// Base metadata shared by proxy messages.
 abstract class ProxyMessageBase {
+  /// Creates proxy message metadata.
   const ProxyMessageBase({this.id, this.type});
 
   final int? id;
   final String? type;
 }
 
+/// Generic proxy message containing args, response, or error payloads.
 class ProxyMessage<T> extends ProxyMessageBase {
+  /// Creates a proxy message.
   const ProxyMessage({
     this.error,
     this.response,
@@ -46,6 +52,7 @@ class ProxyMessage<T> extends ProxyMessageBase {
   final T? response;
   final List<dynamic>? args;
 
+  /// Converts this message to a JSON-like map.
   Map<String, dynamic> toJson() {
     return {
       'id': id,
@@ -57,6 +64,7 @@ class ProxyMessage<T> extends ProxyMessageBase {
   }
 }
 
+/// Proxy message for propagated backend errors.
 class ProxyMessageError<T> extends ProxyMessage<T> {
   const ProxyMessageError({
     super.error,
@@ -77,6 +85,7 @@ class ProxyMessageError<T> extends ProxyMessage<T> {
   }
 }
 
+/// Proxy request for the agent principal.
 class ProxyMessageGetPrincipal extends ProxyMessage {
   const ProxyMessageGetPrincipal({
     super.error,
@@ -97,6 +106,7 @@ class ProxyMessageGetPrincipal extends ProxyMessage {
   }
 }
 
+/// Proxy response containing the agent principal text.
 class ProxyMessageGetPrincipalResponse extends ProxyMessage<String> {
   const ProxyMessageGetPrincipalResponse({
     super.response,
@@ -113,6 +123,7 @@ class ProxyMessageGetPrincipalResponse extends ProxyMessage<String> {
   }
 }
 
+/// Proxy request for a canister query call.
 class ProxyMessageQuery extends ProxyMessage {
   //: [string, QueryFields];
   const ProxyMessageQuery({
@@ -134,6 +145,7 @@ class ProxyMessageQuery extends ProxyMessage {
   }
 }
 
+/// Proxy response containing a query result.
 class ProxyMessageQueryResponse extends ProxyMessage<QueryResponse> {
   const ProxyMessageQueryResponse({
     super.error,
@@ -154,6 +166,7 @@ class ProxyMessageQueryResponse extends ProxyMessage<QueryResponse> {
   }
 }
 
+/// Proxy request for an update call.
 class ProxyMessageCall extends ProxyMessage {
   const ProxyMessageCall({
     super.error,
@@ -174,6 +187,7 @@ class ProxyMessageCall extends ProxyMessage {
   }
 }
 
+/// Proxy response containing an update-call result.
 class ProxyMessageCallResponse extends ProxyMessage<SubmitResponse> {
   const ProxyMessageCallResponse({
     super.error,
@@ -194,6 +208,7 @@ class ProxyMessageCallResponse extends ProxyMessage<SubmitResponse> {
   }
 }
 
+/// Proxy request for a read-state call.
 class ProxyMessageReadState extends ProxyMessage {
   const ProxyMessageReadState({
     super.error,
@@ -214,6 +229,7 @@ class ProxyMessageReadState extends ProxyMessage {
   }
 }
 
+/// Proxy response containing a read-state result.
 class ProxyMessageReadStateResponse extends ProxyMessage<ReadStateResponse> {
   const ProxyMessageReadStateResponse({
     super.error,
@@ -234,6 +250,7 @@ class ProxyMessageReadStateResponse extends ProxyMessage<ReadStateResponse> {
   }
 }
 
+/// Proxy request for replica status.
 class ProxyMessageStatus extends ProxyMessage {
   const ProxyMessageStatus({
     super.error,
@@ -254,6 +271,7 @@ class ProxyMessageStatus extends ProxyMessage {
   }
 }
 
+/// Proxy response containing replica status.
 class ProxyMessageStatusResponse extends ProxyMessage<Map> {
   const ProxyMessageStatusResponse({
     super.error,
@@ -274,12 +292,15 @@ class ProxyMessageStatusResponse extends ProxyMessage<Map> {
   }
 }
 
+/// Backend-side bridge that services proxy agent messages.
 class ProxyStubAgent {
+  /// Creates a proxy stub for forwarding responses to [_frontend].
   const ProxyStubAgent(this._frontend, this._agent);
 
   final void Function(ProxyMessage msg) _frontend;
   final Agent _agent;
 
+  /// Handles an inbound proxy message.
   void onMessage(ProxyMessage msg) {
     switch (msg.type) {
       case ProxyMessageKind.getPrincipal:
@@ -345,7 +366,9 @@ class ProxyStubAgent {
   }
 }
 
+/// Agent implementation that forwards calls through proxy messages.
 class ProxyAgent implements Agent {
+  /// Creates a proxy agent that sends messages to [_backend].
   ProxyAgent(this._backend);
 
   final void Function(ProxyMessage msg) _backend;

--- a/packages/agent_dart_base/lib/agent/auth.dart
+++ b/packages/agent_dart_base/lib/agent/auth.dart
@@ -12,21 +12,32 @@ import 'types.dart';
 /// A Key Pair, containing a secret and public key.
 @immutable
 abstract class KeyPair {
+  /// Creates a key pair from a [secretKey] and [publicKey].
   const KeyPair({required this.secretKey, required this.publicKey});
 
+  /// Private key material used by the corresponding identity.
   final BinaryBlob secretKey;
+
+  /// Public key associated with [secretKey].
   final PublicKey publicKey;
 }
 
+/// Public key material that can be serialized for IC requests.
 @immutable
 abstract class PublicKey {
+  /// Creates a public key abstraction.
   const PublicKey();
 
-  // Get the public key bytes encoded with DER.
+  /// Returns the public key bytes encoded with DER.
   DerEncodedBlob toDer();
 }
 
+/// An entity that can identify itself to the Internet Computer.
+///
+/// Identities provide a [Principal] and can transform outgoing HTTP agent
+/// requests into authenticated or anonymous request envelopes.
 abstract class Identity {
+  /// Creates an identity abstraction.
   const Identity();
 
   /// Get the principal represented by this identity. Normally should be a
@@ -49,6 +60,7 @@ abstract class SignIdentity implements Identity {
   /// Signs a blob of data, with this identity's private key.
   Future<BinaryBlob> sign(BinaryBlob blob);
 
+  /// Returns the IC ledger account identifier for this identity's principal.
   Uint8List getAccountId() {
     return Principal.selfAuthenticating(getPublicKey().toDer()).toAccountId();
   }
@@ -85,8 +97,13 @@ abstract class SignIdentity implements Identity {
   }
 }
 
+/// An identity for anonymous IC requests.
+///
+/// Anonymous identities attach the anonymous principal and do not sign request
+/// envelopes.
 @immutable
 class AnonymousIdentity implements Identity {
+  /// Creates an anonymous identity.
   const AnonymousIdentity();
 
   @override

--- a/packages/agent_dart_base/lib/agent/bls.dart
+++ b/packages/agent_dart_base/lib/agent/bls.dart
@@ -2,17 +2,22 @@ import 'dart:typed_data';
 
 import 'package:agent_dart_ffi/agent_dart_ffi.dart' as ffi;
 
+/// Wrapper around native BLS initialization and verification.
 class AgentBLS {
+  /// Creates a BLS helper.
   AgentBLS();
 
+  /// Whether the native BLS library has been initialized.
   bool get isInit => _isInit;
   late bool _isInit = false;
 
+  /// Initializes the native BLS implementation.
   Future<bool> blsInit() async {
     _isInit = await ffi.blsInit();
     return _isInit;
   }
 
+  /// Verifies a BLS [sig] over [msg] with public key [pk].
   Future<bool> blsVerify(
     Uint8List pk,
     Uint8List sig,

--- a/packages/agent_dart_base/lib/agent/canisters/asset_idl.dart
+++ b/packages/agent_dart_base/lib/agent/canisters/asset_idl.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import '../../candid/idl.dart';
 import '../actor.dart';
 
+/// Returns the Candid service definition for the asset canister.
 Service assetIDL() {
   return IDL.Service({
     'retrieve': IDL.Func([IDL.Text], [IDL.Vec(IDL.Nat8)], ['query']),
@@ -10,14 +11,17 @@ Service assetIDL() {
   });
 }
 
+/// Asset canister method names.
 enum AssetMethod { retrieve, store }
 
 /// Try to understand how idl can be transformed.
 class AssetActor {
+  /// Creates an asset actor wrapper.
   AssetActor();
 
   late final CanisterActor actor;
 
+  /// Retrieves asset bytes by [key].
   Future<Uint8List> retrieve(String key) async {
     final res = await actor.getFunc(AssetMethod.retrieve.name)?.call([key]);
     if (res != null) {
@@ -26,6 +30,7 @@ class AssetActor {
     throw StateError('Request failed with the result: $res.');
   }
 
+  /// Stores asset [value] under [key].
   Future<void> store(String key, Uint8List value) async {
     await actor.getFunc(AssetMethod.store.name)?.call([key, value]);
   }

--- a/packages/agent_dart_base/lib/agent/cbor.dart
+++ b/packages/agent_dart_base/lib/agent/cbor.dart
@@ -13,7 +13,9 @@ const _kIsWeb = bool.hasEnvironment('dart.library.js_util')
     : identical(0, 0.0);
 
 @immutable
+/// Encoder extension point for values not handled by the base CBOR encoder.
 abstract class ExtraEncoder<T> {
+  /// Creates an extra encoder named [name].
   const ExtraEncoder({required this.name});
 
   final String name;
@@ -23,7 +25,9 @@ abstract class ExtraEncoder<T> {
   void write(cbor.Encoder encoder, T value);
 }
 
+/// CBOR encoder that writes the self-describing CBOR tag by default.
 class SelfDescribeEncoder extends cbor.Encoder {
+  /// Creates a self-describing encoder backed by [_out].
   SelfDescribeEncoder(this._out) : super(_out) {
     final valBuff = Uint8Buffer();
     final hList = Uint8List.fromList([0xd9, 0xd9, 0xf7]);
@@ -31,19 +35,23 @@ class SelfDescribeEncoder extends cbor.Encoder {
     addBuilderOutput(valBuff);
   }
 
+  /// Creates an encoder without writing the self-describing CBOR tag.
   SelfDescribeEncoder.noHead(this._out) : super(_out);
 
   late final cbor.Output _out;
   final Set<ExtraEncoder> _encoders = {};
 
+  /// Registers an extra encoder.
   void addEncoder<T>(ExtraEncoder encoder) {
     _encoders.add(encoder);
   }
 
+  /// Removes an extra encoder by name.
   void removeEncoder<T>(String encoderName) {
     _encoders.removeWhere((element) => element.name == encoderName);
   }
 
+  /// Returns the first extra encoder that can handle [value].
   ExtraEncoder? getEncoderFor<T>(dynamic value) {
     for (final encoder in _encoders) {
       if (encoder.match(value)) {
@@ -53,6 +61,7 @@ class SelfDescribeEncoder extends cbor.Encoder {
     return null;
   }
 
+  /// Serializes [val] into the underlying CBOR output.
   void serialize(dynamic val) {
     if (val is Map) {
       serializeMap(val);
@@ -191,6 +200,7 @@ class SelfDescribeEncoder extends cbor.Encoder {
   }
 }
 
+/// Extra CBOR encoder for principals.
 class PrincipalEncoder extends ExtraEncoder<Principal> {
   const PrincipalEncoder() : super(name: 'Principal');
 
@@ -205,6 +215,7 @@ class PrincipalEncoder extends ExtraEncoder<Principal> {
   }
 }
 
+/// Extra CBOR encoder for binary blobs.
 class BufferEncoder extends ExtraEncoder<BinaryBlob> {
   const BufferEncoder() : super(name: 'Buffer');
 
@@ -219,6 +230,7 @@ class BufferEncoder extends ExtraEncoder<BinaryBlob> {
   }
 }
 
+/// Extra CBOR encoder for byte buffers.
 class ByteBufferEncoder extends ExtraEncoder<ByteBuffer> {
   const ByteBufferEncoder() : super(name: 'ByteBuffer');
 
@@ -233,6 +245,7 @@ class ByteBufferEncoder extends ExtraEncoder<ByteBuffer> {
   }
 }
 
+/// Extra CBOR encoder for big integers.
 class BigIntEncoder extends ExtraEncoder<BigInt> {
   const BigIntEncoder() : super(name: 'BigInt');
 
@@ -246,12 +259,15 @@ class BigIntEncoder extends ExtraEncoder<BigInt> {
 }
 
 @immutable
+/// Interface for values that write themselves to a CBOR encoder.
 abstract class ToCborable {
+  /// Creates a CBOR-writable value.
   const ToCborable();
 
   void write(cbor.Encoder encoder);
 }
 
+/// Creates a CBOR serializer with default extra encoders and a header.
 SelfDescribeEncoder initCborSerializer() {
   cbor.init();
   final output = cbor.OutputStandard();
@@ -267,6 +283,7 @@ SelfDescribeEncoder initCborSerializer() {
     ..addEncoder(byteBufferEncoder);
 }
 
+/// Creates a CBOR serializer with default extra encoders and no header.
 SelfDescribeEncoder initCborSerializerNoHead() {
   cbor.init();
   final output = cbor.OutputStandard();
@@ -282,12 +299,14 @@ SelfDescribeEncoder initCborSerializerNoHead() {
     ..addEncoder(byteBufferEncoder);
 }
 
+/// Encodes [value] to CBOR bytes.
 Uint8List cborEncode(dynamic value, {SelfDescribeEncoder? withSerializer}) {
   final serializer = withSerializer ?? initCborSerializer();
   serializer.serialize(value);
   return Uint8List.fromList(serializer._out.getData());
 }
 
+/// Decodes CBOR [value] into a Dart object.
 T cborDecode<T>(List<int> value) {
   final buffer = value is Uint8Buffer ? value : Uint8Buffer()
     ..addAll(value);
@@ -302,6 +321,7 @@ T cborDecode<T>(List<int> value) {
   return walked![0] as T;
 }
 
+/// Serializes a numeric CBOR value from its hexadecimal representation.
 ByteBuffer serializeValue(int major, int minor, String val) {
   // Remove everything that's not an hexadecimal character. These are not
   // considered errors since the value was already validated and they might

--- a/packages/agent_dart_base/lib/agent/certificate.dart
+++ b/packages/agent_dart_base/lib/agent/certificate.dart
@@ -19,7 +19,9 @@ final AgentBLS _bls = AgentBLS();
 
 /// A certificate needs to be verified (using Certificate.prototype.verify)
 /// before it can be used.
+/// Error thrown when certificate data is used before successful verification.
 class UnverifiedCertificateError extends AgentFetchError {
+  /// Creates an unverified certificate error.
   UnverifiedCertificateError([this.reason = 'Certificate is not verified.']);
 
   final String reason;
@@ -34,6 +36,7 @@ class UnverifiedCertificateError extends AgentFetchError {
 ///   | [2, ArrayBuffer, HashTree]
 ///   | [3, ArrayBuffer]
 ///   | [4, ArrayBuffer];
+/// Hash tree node identifiers used by certificate reconstruction.
 enum NodeId {
   empty(0),
   fork(1),
@@ -43,6 +46,7 @@ enum NodeId {
 
   const NodeId(this._value);
 
+  /// Parses a node identifier from its numeric representation.
   factory NodeId.fromValue(int value) {
     return values.singleWhere((e) => e._value == value);
   }
@@ -50,13 +54,16 @@ enum NodeId {
   final int _value;
 }
 
+/// Decoded certificate payload.
 class Cert {
+  /// Creates a decoded certificate payload.
   const Cert({
     required this.tree,
     required this.signature,
     required this.delegation,
   });
 
+  /// Creates a certificate payload from decoded CBOR data.
   factory Cert.fromJson(Map json) {
     return Cert(
       tree: json['tree'],
@@ -107,12 +114,15 @@ String hashTreeToString(List tree) {
   }
 }
 
+/// Certificate delegation to a subnet.
 class CertDelegation extends ReadStateResponse {
+  /// Creates a certificate delegation.
   const CertDelegation(
     BinaryBlob certificate,
     this.subnetId,
   ) : super(certificate: certificate);
 
+  /// Creates a certificate delegation from decoded CBOR data.
   factory CertDelegation.fromJson(Map<String, dynamic> json) {
     return CertDelegation(
       json['certificate'] is Uint8List || json['certificate'] is Uint8Buffer
@@ -132,7 +142,9 @@ class CertDelegation extends ReadStateResponse {
   }
 }
 
+/// Verifiable Internet Computer certificate.
 class Certificate {
+  /// Creates a certificate from encoded certificate bytes.
   Certificate({
     required BinaryBlob cert,
     required this.canisterId,
@@ -148,14 +160,17 @@ class Certificate {
 
   bool verified = false;
 
+  /// Looks up a raw path in the verified certificate tree.
   Uint8List? lookup(List path) {
     return lookupPath(path, cert.tree);
   }
 
+  /// Looks up a path containing string or byte labels in the certificate tree.
   Uint8List? lookupEx(List path) {
     return lookupPathEx(path, cert.tree);
   }
 
+  /// Verifies the certificate signature and delegation chain.
   Future<bool> verify() async {
     _verifyCertTime();
     final rootHash = await reconstruct(cert.tree);
@@ -168,6 +183,7 @@ class Certificate {
     return res;
   }
 
+  /// Throws if this certificate has not been verified.
   void checkState() {
     if (!verified) {
       throw UnverifiedCertificateError();
@@ -257,6 +273,7 @@ final _derPrefix =
 
 const _keyLength = 96;
 
+/// Extracts the raw BLS public key from a DER-encoded key.
 Uint8List extractDER(Uint8List buf) {
   final expectedLength = _derPrefix.length + _keyLength;
   if (buf.length != expectedLength) {
@@ -272,6 +289,7 @@ Uint8List extractDER(Uint8List buf) {
   return buf.sublist(_derPrefix.length);
 }
 
+/// Reconstructs a hash tree root from a decoded certificate tree.
 Future<Uint8List> reconstruct(List t) async {
   final nodeId = NodeId.fromValue(t[0]);
   switch (nodeId) {
@@ -311,11 +329,13 @@ Future<Uint8List> reconstruct(List t) async {
   }
 }
 
+/// Creates a domain separator byte prefix for [s].
 Uint8List domainSep(String s) {
   final buf = Uint8List.fromList(List<int>.filled(1, s.length));
   return u8aConcat([buf, s.plainToU8a(useDartEncode: true)]);
 }
 
+/// Looks up a path using string or byte labels in a hash tree.
 Uint8List? lookupPathEx(List path, List tree) {
   final maybeReturn = lookupPath(
     path.map((p) {
@@ -330,6 +350,7 @@ Uint8List? lookupPathEx(List path, List tree) {
   return maybeReturn;
 }
 
+/// Looks up a raw byte path in a hash tree.
 Uint8List? lookupPath(List path, List tree) {
   if (path.isEmpty) {
     final NodeId nodeId = NodeId.fromValue(tree[0]);
@@ -352,6 +373,7 @@ Uint8List? lookupPath(List path, List tree) {
   return null;
 }
 
+/// Flattens fork nodes into a list of labelled subtrees.
 List<List> flattenForks(List t) {
   final NodeId nodeId = NodeId.fromValue(t[0]);
   switch (nodeId) {
@@ -366,6 +388,7 @@ List<List> flattenForks(List t) {
   }
 }
 
+/// Finds a labelled subtree matching [l].
 List? findLabel(Uint8List l, List<List> trees) {
   if (trees.isEmpty) {
     return null;

--- a/packages/agent_dart_base/lib/agent/polling/polling.dart
+++ b/packages/agent_dart_base/lib/agent/polling/polling.dart
@@ -9,6 +9,11 @@ import 'strategy.dart';
 
 export 'strategy.dart';
 
+/// Polls read-state until an update call returns a reply or terminal state.
+///
+/// [strategy] controls the delay, timeout, and retry behavior between polling
+/// attempts. When [overrideCertificate] is supplied, it is used for the first
+/// response check instead of fetching a certificate from the replica.
 Future<BinaryBlob> pollForResponse(
   Agent agent,
   Principal canisterId,
@@ -97,7 +102,9 @@ Future<BinaryBlob> pollForResponse(
   }
 }
 
+/// Base exception for update-call polling failures.
 class PollingResponseException implements Exception {
+  /// Creates a polling exception with request context.
   const PollingResponseException({
     required this.canisterId,
     required this.requestId,
@@ -106,10 +113,19 @@ class PollingResponseException implements Exception {
     this.caller,
   });
 
+  /// Canister that handled the update call.
   final Principal canisterId;
+
+  /// Hex-encoded request ID.
   final String requestId;
+
+  /// Terminal or current request status.
   final RequestStatusResponseStatus status;
+
+  /// Canister method name being polled.
   final String method;
+
+  /// Caller principal when it is available from the agent.
   final Principal? caller;
 
   @override
@@ -122,7 +138,9 @@ class PollingResponseException implements Exception {
   }
 }
 
+/// Thrown when a request reaches `done` without a reply payload.
 class PollingResponseNoReplyException extends PollingResponseException {
+  /// Creates a no-reply polling exception.
   const PollingResponseNoReplyException({
     required super.canisterId,
     required super.requestId,
@@ -141,7 +159,9 @@ class PollingResponseNoReplyException extends PollingResponseException {
   }
 }
 
+/// Thrown when the replica reports a rejected update-call status.
 class PollingResponseRejectedException extends PollingResponseException {
+  /// Creates a rejected polling exception.
   const PollingResponseRejectedException({
     required super.canisterId,
     required super.requestId,
@@ -152,7 +172,10 @@ class PollingResponseRejectedException extends PollingResponseException {
     super.caller,
   });
 
+  /// Replica reject code.
   final BigInt rejectCode;
+
+  /// Replica reject message.
   final String rejectMessage;
 
   @override

--- a/packages/agent_dart_base/lib/agent/polling/strategy.dart
+++ b/packages/agent_dart_base/lib/agent/polling/strategy.dart
@@ -3,18 +3,25 @@ import 'dart:async';
 import '../../principal/principal.dart';
 import '../agent.dart';
 
+/// Creates a polling strategy for update-call response polling.
 typedef PollStrategyFactory = PollStrategy Function();
+
+/// Strategy invoked between read-state polling attempts.
 typedef PollStrategy = Future<void> Function(
   Principal canisterId,
   RequestId requestId,
   RequestStatusResponseStatus status,
 );
+/// Predicate used by conditional polling strategies.
 typedef PollPredicate<T> = Future<T> Function(
   Principal canisterId,
   RequestId requestId,
   RequestStatusResponseStatus status,
 );
 
+/// Default polling strategy used for update calls.
+///
+/// It waits once, then applies a small backoff until the default timeout.
 PollStrategy defaultStrategy() {
   return chain([
     conditionalDelay(once(), 1000),
@@ -23,6 +30,7 @@ PollStrategy defaultStrategy() {
   ]);
 }
 
+/// Returns true only for the first invocation.
 PollPredicate<bool> once() {
   bool first = true;
   return (
@@ -38,6 +46,7 @@ PollPredicate<bool> once() {
   };
 }
 
+/// Delays polling by [timeInMsec] when [condition] returns true.
 PollStrategy conditionalDelay(PollPredicate<bool> condition, int timeInMsec) {
   return (
     Principal canisterId,
@@ -52,6 +61,7 @@ PollStrategy conditionalDelay(PollPredicate<bool> condition, int timeInMsec) {
   };
 }
 
+/// Fails polling after [count] attempts.
 PollStrategy maxAttempts(int count) {
   int attempts = count;
   return (
@@ -84,6 +94,7 @@ PollStrategy throttlePolling(int throttleMilliseconds) {
   };
 }
 
+/// Fails polling after [duration] has elapsed.
 PollStrategy timeout(Duration duration) {
   final end = DateTime.now().add(duration);
   return (
@@ -102,6 +113,7 @@ PollStrategy timeout(Duration duration) {
   };
 }
 
+/// Delays polling with multiplicative backoff.
 PollStrategy backoff(num startingThrottleInMsec, num backoffFactor) {
   return (
     Principal canisterId,
@@ -117,6 +129,7 @@ PollStrategy backoff(num startingThrottleInMsec, num backoffFactor) {
   };
 }
 
+/// Runs [strategies] in sequence for each polling attempt.
 PollStrategy chain(List<PollStrategy> strategies) {
   return (
     Principal canisterId,

--- a/packages/agent_dart_base/lib/agent/request_id.dart
+++ b/packages/agent_dart_base/lib/agent/request_id.dart
@@ -11,30 +11,38 @@ import 'agent/index.dart';
 import 'types.dart';
 import 'utils/leb128.dart';
 
+/// Interface for values that can produce a representation-independent hash.
 @immutable
 abstract class ToHashable {
+  /// Creates a hashable value.
   const ToHashable();
 
+  /// Returns the value to feed into request ID hashing.
   dynamic Function() toHash();
 }
 
+/// Converts a request ID to hex.
 String requestIdToHex(RequestId requestId) {
   return blobToHex(requestId);
 }
 
+/// Computes a SHA-256 hash of [data].
 BinaryBlob hash(Uint8List data) {
   final hashed = sha256.convert(data).bytes;
   return Uint8List.fromList(hashed);
 }
 
+/// Computes a SHA-256 hash of [value] encoded as UTF-8.
 BinaryBlob hashString(String value) {
   return hash(Uint8List.fromList(value.plainToU8a()));
 }
 
+/// Concatenates multiple binary blobs.
 BinaryBlob concat(List<BinaryBlob> bs) {
   return blobFromBuffer(u8aConcat(bs.map((b) => b.buffer).toList()).buffer);
 }
 
+/// Computes the representation-independent hash of a supported value.
 BinaryBlob hashValue(dynamic value) {
   if (value is String) {
     return hashString(value);
@@ -70,6 +78,7 @@ BinaryBlob hashValue(dynamic value) {
   );
 }
 
+/// Compares two lists lexicographically using the elements' natural order.
 int compareLists<T extends Comparable<T>>(List<T> a, List<T> b) {
   final aLength = a.length;
   final bLength = b.length;
@@ -81,6 +90,7 @@ int compareLists<T extends Comparable<T>>(List<T> a, List<T> b) {
   return aLength - bLength;
 }
 
+/// Compares two lists lexicographically using a custom comparator.
 int compareListsBy<T>(List<T> a, List<T> b, int Function(T a, T b) compare) {
   final aLength = a.length;
   final bLength = b.length;
@@ -92,12 +102,16 @@ int compareListsBy<T>(List<T> a, List<T> b, int Function(T a, T b) compare) {
   return aLength - bLength;
 }
 
+/// Adds lexicographic comparison with a custom comparator to lists.
 extension CompareListExtension<T> on List<T> {
+  /// Compares this list to [other] using [compare].
   int compare(List<T> other, int Function(T a, T b) compare) =>
       compareListsBy<T>(this, other, compare);
 }
 
+/// Adds lexicographic comparison to lists of comparable values.
 extension CompareListComparableExtension<T extends Comparable<T>> on List<T> {
+  /// Compares this list to [other] using natural ordering or [compare].
   int compare(List<T> other, [int Function(T a, T b)? compare]) =>
       compareListsBy<T>(this, other, compare!);
 }

--- a/packages/agent_dart_base/lib/agent/types.dart
+++ b/packages/agent_dart_base/lib/agent/types.dart
@@ -6,6 +6,7 @@ import 'package:meta/meta.dart';
 import '../../utils/extension.dart';
 import 'utils/leb128.dart';
 
+/// HTTP methods supported by the agent transport layer.
 enum FetchMethod {
   get,
   head,
@@ -18,6 +19,7 @@ enum FetchMethod {
   patch,
 }
 
+/// Request status values returned by the replica read-state endpoint.
 enum RequestStatusResponseStatus {
   received,
   processing,
@@ -26,15 +28,19 @@ enum RequestStatusResponseStatus {
   unknown,
   done;
 
+  /// Parses a request status from its wire-format [value].
   factory RequestStatusResponseStatus.fromName(String value) {
     return values.singleWhere((e) => e.name == value);
   }
 }
 
+/// Semantic blob categories used by agent request helpers.
 enum BlobType { binary, der, nonce, requestId }
 
+/// Base type for strongly labelled binary blobs.
 @immutable
 abstract class BaseBlob {
+  /// Creates a blob wrapper with type and name metadata.
   const BaseBlob(
     Uint8List buffer,
     this.blobType,
@@ -42,61 +48,87 @@ abstract class BaseBlob {
   ) : _buffer = buffer;
 
   final Uint8List _buffer;
+  /// Semantic type of this blob.
   final BlobType blobType;
+
+  /// Human-readable blob name.
   final String blobName;
 
+  /// Raw bytes for this blob.
   Uint8List get buffer => _buffer;
 
+  /// Number of bytes in this blob.
   int get byteLength;
 }
 
+/// Raw binary blob used by agent request encoding.
 typedef BinaryBlob = Uint8List;
+
+/// DER-encoded binary blob.
 typedef DerEncodedBlob = BinaryBlob;
+
+/// Request nonce bytes.
 typedef Nonce = BinaryBlob;
+
+/// Request ID bytes.
 typedef RequestId = BinaryBlob;
 
+/// Convenience extension for binary blob metadata and copying.
 extension ExtBinaryBlob on BinaryBlob {
+  /// Marker name used by CBOR encoding helpers.
   String get name => '__BLOB';
 
+  /// Blob type for raw binary blobs.
   BlobType get blobType => BlobType.binary;
 
+  /// Number of bytes in this blob.
   int get byteLength => lengthInBytes;
 
+  /// Returns a copy of [other].
   static Uint8List from(Uint8List other) => Uint8List.fromList(other);
 }
 
+/// Creates a [BinaryBlob] from a byte buffer.
 BinaryBlob blobFromBuffer(ByteBuffer b) {
   return BinaryBlob.fromList(b.asUint8List());
 }
 
+/// Creates a [BinaryBlob] from a [Uint8List].
 BinaryBlob blobFromUint8Array(Uint8List arr) {
   return BinaryBlob.fromList(arr);
 }
 
+/// Creates a UTF-8 [BinaryBlob] from [text].
 BinaryBlob blobFromText(String text) {
   return BinaryBlob.fromList(text.plainToU8a(useDartEncode: true));
 }
 
+/// Creates a [BinaryBlob] from a 32-bit integer array.
 BinaryBlob blobFromUint32Array(Uint32List arr) {
   return BinaryBlob.fromList(arr.buffer.asUint8List());
 }
 
+/// Treats [blob] as DER-encoded bytes.
 DerEncodedBlob derBlobFromBlob(BinaryBlob blob) {
   return DerEncodedBlob.fromList(blob);
 }
 
+/// Parses a hex string into a [BinaryBlob].
 BinaryBlob blobFromHex(String hex) {
   return BinaryBlob.fromList(hex.toU8a());
 }
 
+/// Converts a [BinaryBlob] to hex.
 String blobToHex(BinaryBlob blob) {
   return blob.toHex();
 }
 
+/// Copies a [BinaryBlob] into a [Uint8List].
 Uint8List blobToUint8Array(BinaryBlob blob) {
   return Uint8List.fromList(blob.sublist(0, blob.byteLength));
 }
 
+/// Creates a request nonce from the current timestamp and secure randomness.
 Nonce makeNonce() {
   return Nonce.fromList(
     lebEncode(

--- a/packages/agent_dart_base/lib/auth_client/auth_client.dart
+++ b/packages/agent_dart_base/lib/auth_client/auth_client.dart
@@ -9,19 +9,27 @@ import '../agent/cbor.dart';
 import '../authentication/authentication.dart';
 import '../identity/identity.dart';
 
+/// Storage key used for the serialized identity.
 const keyLocalStorageKey = 'identity';
+/// Storage key used for the serialized delegation chain.
 const keyLocalStorageDelegation = 'delegation';
+/// Default Internet Identity provider URL.
 const identityProviderDefault = 'https://identity.ic0.app';
+/// Default Internet Identity authorization endpoint fragment.
 const identityProviderEndpoint = '#authorize';
 
+/// Options for creating an authentication client.
 class AuthClientCreateOptions {
+  /// Creates authentication client options.
   const AuthClientCreateOptions({this.identity});
 
   /// An identity to use as the base.
   final SignIdentity? identity;
 }
 
+/// Options for starting an authentication login flow.
 class AuthClientLoginOptions {
+  /// Creates authentication login options.
   const AuthClientLoginOptions({
     this.identityProvider,
     this.maxTimeToLive,
@@ -46,14 +54,18 @@ class AuthClientLoginOptions {
   final void Function(String? error)? onError;
 }
 
+/// Payload passed to the platform-specific authentication function.
 class AuthPayload {
+  /// Creates an authentication payload.
   const AuthPayload(this.url, this.scheme);
 
   final String url;
   final String scheme;
 }
 
+/// Delegation paired with its signature.
 class DelegationWithSignature {
+  /// Creates a signed delegation value.
   const DelegationWithSignature({
     required this.delegation,
     required this.signature,
@@ -63,7 +75,9 @@ class DelegationWithSignature {
   final Uint8List signature;
 }
 
+/// Authentication state restored from storage.
 class FromStorageResult {
+  /// Creates a storage restoration result.
   const FromStorageResult({
     this.delegationChain,
     this.signIdentity,
@@ -76,12 +90,15 @@ class FromStorageResult {
 }
 
 @immutable
+/// Base response returned by an authentication provider.
 abstract class AuthResponse {
+  /// Creates an authentication response.
   const AuthResponse({required this.kind});
 
   final String kind;
 }
 
+/// Successful authentication response.
 class AuthResponseSuccess extends AuthResponse {
   const AuthResponseSuccess({
     required this.delegations,
@@ -93,6 +110,7 @@ class AuthResponseSuccess extends AuthResponse {
   final Uint8List userPublicKey;
 }
 
+/// Failed authentication response.
 class AuthResponseFailure extends AuthResponse {
   const AuthResponseFailure({
     required this.text,
@@ -102,9 +120,12 @@ class AuthResponseFailure extends AuthResponse {
   final String text;
 }
 
+/// Function that launches an auth flow and returns a callback URL.
 typedef AuthFunction = Future<String> Function(AuthPayload paylod);
 
+/// Client for Internet Identity-style authentication flows.
 class AuthClient {
+  /// Creates an authentication client.
   AuthClient({
     required this.scheme,
     required this.authFunction,
@@ -115,6 +136,7 @@ class AuthClient {
     Identity? identity,
   }) : identity = identity ?? const AnonymousIdentity();
 
+  /// Restores an authentication client from serialized state.
   factory AuthClient.fromJson(
     String scheme,
     AuthFunction authFunction,
@@ -147,6 +169,7 @@ class AuthClient {
   Identity? identity;
   DelegationChain? chain;
 
+  /// Restores authentication identities and delegations from storage JSON.
   static FromStorageResult fromStorage(String str) {
     final map = Map<String, dynamic>.from(jsonDecode(str));
     final identityString = map[keyLocalStorageKey] as String?;
@@ -170,6 +193,7 @@ class AuthClient {
     );
   }
 
+  /// Handles a successful authentication response.
   void handleSuccess(AuthResponseSuccess message, void Function()? onSuccess) {
     final delegations = message.delegations.map((signedDelegation) {
       return SignedDelegation.fromJson({
@@ -193,6 +217,7 @@ class AuthClient {
     onSuccess?.call();
   }
 
+  /// Handles a failed authentication response.
   void handleFailure(
     String? errorMessage,
     void Function(String? error)? onError,
@@ -200,16 +225,19 @@ class AuthClient {
     onError?.call(errorMessage);
   }
 
+  /// Returns the current authenticated identity, if available.
   Identity? getIdentity() {
     return identity;
   }
 
+  /// Whether the client currently has a non-anonymous authenticated identity.
   Future<bool> isAuthenticated() async {
     return getIdentity() != null &&
         !getIdentity()!.getPrincipal().isAnonymous() &&
         chain != null;
   }
 
+  /// Starts the authentication flow.
   Future<void> login([AuthClientLoginOptions? options]) async {
     key ??= await Ed25519KeyIdentity.generate(null);
     // Create the URL of the IDP. (e.g. https://XXXX/#authorize)
@@ -284,6 +312,7 @@ class AuthClient {
     return AuthPayload(identityProviderUrl.toString(), scheme);
   }
 
+  /// Serializes the current authentication state for storage.
   String toStorage() {
     return jsonEncode(
       {
@@ -297,6 +326,7 @@ class AuthClient {
   }
 }
 
+/// Parses a stringified byte list into bytes.
 Uint8List parseStringToU8a(String str) {
   final s1 = str.replaceAll('[', '');
   final s2 = s1.replaceAll(']', '');

--- a/packages/agent_dart_base/lib/identity/ed25519.dart
+++ b/packages/agent_dart_base/lib/identity/ed25519.dart
@@ -11,33 +11,46 @@ import '../agent/types.dart';
 import '../utils/extension.dart';
 import 'der.dart';
 
+/// An Ed25519 key pair containing DER-capable public key and raw secret key.
 @immutable
 class Ed25519KeyPair extends auth.KeyPair {
+  /// Creates an Ed25519 key pair.
   const Ed25519KeyPair({required super.publicKey, required super.secretKey});
 
+  /// Serializes the key pair as `[publicKeyDerHex, secretKeyHex]`.
   List<String> toJson() {
     return [publicKey.toDer().toHex(), secretKey.toHex()];
   }
 }
 
+/// An Ed25519 public key used by [Ed25519KeyIdentity].
+///
+/// The key can be constructed from raw 32-byte key material or DER-encoded
+/// bytes and can serialize itself back to DER for IC signatures.
 class Ed25519PublicKey implements auth.PublicKey {
   /// [Ed25519PublicKey.fromRaw] and [Ed25519PublicKey.fromDer] should not be
   /// used for instantiation in this constructor.
   Ed25519PublicKey(this.rawKey);
 
+  /// Creates an Ed25519 key by re-decoding another public key's DER encoding.
   factory Ed25519PublicKey.from(auth.PublicKey key) {
     return Ed25519PublicKey.fromDer(key.toDer());
   }
 
+  /// Creates a public key from raw 32-byte Ed25519 key material.
   factory Ed25519PublicKey.fromRaw(BinaryBlob rawKey) {
     return Ed25519PublicKey(rawKey);
   }
 
+  /// Creates a public key from DER-encoded Ed25519 key bytes.
   factory Ed25519PublicKey.fromDer(BinaryBlob derKey) {
     return Ed25519PublicKey(Ed25519PublicKey.derDecode(derKey));
   }
 
+  /// The raw 32-byte Ed25519 public key.
   final BinaryBlob rawKey;
+
+  /// The DER-encoded form of [rawKey].
   late final DerEncodedBlob derKey = Ed25519PublicKey.derEncode(rawKey);
 
   /// The length of Ed25519 public keys is always 32 bytes.
@@ -55,10 +68,12 @@ class Ed25519PublicKey implements auth.PublicKey {
     ...[0], // 'no padding'
   ]);
 
+  /// DER-encodes a raw Ed25519 [publicKey].
   static DerEncodedBlob derEncode(BinaryBlob publicKey) {
     return bytesWrapDer(publicKey, oidEd25519);
   }
 
+  /// Unwraps a DER-encoded Ed25519 public [key] into raw key bytes.
   static BinaryBlob derDecode(BinaryBlob key) {
     final unwrapped = bytesUnwrapDer(key, oidEd25519);
     if (unwrapped.length != rawKeyLength) {
@@ -71,12 +86,19 @@ class Ed25519PublicKey implements auth.PublicKey {
     return unwrapped;
   }
 
+  /// Returns the DER encoding of this public key.
   @override
   DerEncodedBlob toDer() => derKey;
 
+  /// Returns the raw 32-byte Ed25519 public key.
   BinaryBlob toRaw() => rawKey;
 }
 
+/// A signing identity backed by an Ed25519 seed.
+///
+/// This identity can sign ingress messages, export/import the legacy JSON key
+/// format used by agent-js compatible tooling, and recover Internet Identity
+/// seed-phrase based identities.
 class Ed25519KeyIdentity extends auth.SignIdentity {
   /// [Ed25519PublicKey.fromRaw] and [Ed25519PublicKey.fromDer] should not be
   /// used for instantiation in this constructor.
@@ -85,6 +107,7 @@ class Ed25519KeyIdentity extends auth.SignIdentity {
     this._seed,
   ) : _publicKey = Ed25519PublicKey.from(publicKey);
 
+  /// Creates an identity from raw public and private key bytes.
   factory Ed25519KeyIdentity.fromKeyPair(
     BinaryBlob publicKey,
     BinaryBlob privateKey,
@@ -92,6 +115,10 @@ class Ed25519KeyIdentity extends auth.SignIdentity {
     return Ed25519KeyIdentity(Ed25519PublicKey.fromRaw(publicKey), privateKey);
   }
 
+  /// Restores an identity from a JSON string.
+  ///
+  /// Accepts both the `[publicKeyDerHex, secretKeyHex]` tuple format and the
+  /// object shape used by older agent-js exports.
   factory Ed25519KeyIdentity.fromJSON(String json) {
     final parsed = jsonDecode(json);
     if (parsed is List) {
@@ -131,6 +158,7 @@ class Ed25519KeyIdentity extends auth.SignIdentity {
     throw ArgumentError.value(jsonEncode(json), 'json', 'Invalid json');
   }
 
+  /// Restores an identity from a parsed `[publicKeyDerHex, secretKeyHex]` list.
   factory Ed25519KeyIdentity.fromParsedJson(List<String> obj) {
     return Ed25519KeyIdentity(
       Ed25519PublicKey.fromDer(blobFromHex(obj[0])),
@@ -138,6 +166,10 @@ class Ed25519KeyIdentity extends auth.SignIdentity {
     );
   }
 
+  /// Generates an Ed25519 identity.
+  ///
+  /// When [seed] is provided it must be 32 bytes; otherwise a random seed is
+  /// generated.
   static Future<Ed25519KeyIdentity> generate(Uint8List? seed) async {
     if (seed != null && seed.length != 32) {
       throw RangeError.value(seed.length, 'Expected 32-bytes long but got');
@@ -153,6 +185,7 @@ class Ed25519KeyIdentity extends auth.SignIdentity {
     return Ed25519KeyIdentity(Ed25519PublicKey.fromRaw(publicKey), secretKey);
   }
 
+  /// Recovers an identity from an Internet Identity seed phrase.
   static Future<Ed25519KeyIdentityRecoveredFromII> recoverFromIISeedPhrase(
     String phrase,
   ) async {
@@ -197,6 +230,7 @@ class Ed25519KeyIdentity extends auth.SignIdentity {
     );
   }
 
+  /// Verifies [signature] against [message] using this identity's public key.
   Future<bool> verify(Uint8List signature, Uint8List message) {
     return ed25519Verify(
       req: ED25519VerifyReq(
@@ -208,13 +242,18 @@ class Ed25519KeyIdentity extends auth.SignIdentity {
   }
 }
 
+/// Result of recovering an Ed25519 identity from an Internet Identity phrase.
 class Ed25519KeyIdentityRecoveredFromII {
+  /// Creates a recovered Internet Identity key result.
   const Ed25519KeyIdentityRecoveredFromII({
     required this.identity,
     this.userNumber,
   });
 
+  /// The optional Internet Identity user number embedded in the phrase.
   final BigInt? userNumber;
+
+  /// The recovered Ed25519 signing identity.
   final Ed25519KeyIdentity identity;
 }
 

--- a/packages/agent_dart_base/lib/identity/p256.dart
+++ b/packages/agent_dart_base/lib/identity/p256.dart
@@ -9,63 +9,83 @@ import '../utils/extension.dart';
 import '../wallet/keysmith.dart';
 import 'der.dart';
 
+/// A P-256 key pair containing public and private key material.
 class P256KeyPair extends KeyPair {
+  /// Creates a P-256 key pair.
   const P256KeyPair({required super.publicKey, required super.secretKey});
 
+  /// Serializes the key pair as `[publicKeyDerHex, secretKeyHex]`.
   List<String> toJson() {
     return [publicKey.toDer().toHex(), secretKey.toHex()];
   }
 }
 
+/// Callback used to sign P-256 message bytes.
 typedef SigningFunc = Future<Uint8List> Function(
   Uint8List blob,
   Uint8List seed,
 );
 
+/// Callback used to verify a P-256 signature.
 typedef VerifyFunc = Future<bool> Function(
   Uint8List blob,
   Uint8List signature,
   P256PublicKey publicKey,
 );
 
+/// A P-256 public key that can be encoded for IC request signing.
 class P256PublicKey implements PublicKey {
+  /// Creates a public key from raw P-256 key bytes.
   P256PublicKey(this.rawKey) : assert(rawKey.isNotEmpty);
 
+  /// Creates a public key from raw P-256 key bytes.
   factory P256PublicKey.fromRaw(BinaryBlob rawKey) {
     return P256PublicKey(rawKey);
   }
 
+  /// Creates a public key from DER-encoded P-256 key bytes.
   factory P256PublicKey.fromDer(BinaryBlob derKey) {
     return P256PublicKey(P256PublicKey.derDecode(derKey));
   }
 
+  /// Creates a P-256 public key from another [PublicKey].
   factory P256PublicKey.from(PublicKey key) {
     return P256PublicKey.fromDer(key.toDer());
   }
 
+  /// Raw P-256 public key bytes.
   final BinaryBlob rawKey;
+
+  /// DER-encoded form of [rawKey].
   late final derKey = P256PublicKey.derEncode(rawKey);
 
+  /// DER-encodes a raw P-256 [publicKey].
   static Uint8List derEncode(BinaryBlob publicKey) {
     return bytesWrapDer(publicKey, oidP256);
   }
 
+  /// Decodes a DER-encoded P-256 [publicKey].
   static Uint8List derDecode(BinaryBlob publicKey) {
     return bytesUnwrapDer(publicKey, oidP256);
   }
 
+  /// Returns the DER encoding of this public key.
   @override
   Uint8List toDer() => derKey;
 
+  /// Returns the raw P-256 public key bytes.
   Uint8List toRaw() => rawKey;
 }
 
+/// A signing identity backed by a P-256 private key.
 class P256Identity extends SignIdentity {
+  /// Creates a P-256 identity from a public key and private key bytes.
   P256Identity(
     PublicKey publicKey,
     this._privateKey,
   ) : _publicKey = P256PublicKey.from(publicKey);
 
+  /// Restores an identity from a parsed `[publicKeyHex, privateKeyHex]` list.
   factory P256Identity.fromParsedJson(List<String> obj) {
     return P256Identity(
       P256PublicKey.fromRaw(blobFromHex(obj[0])),
@@ -73,6 +93,7 @@ class P256Identity extends SignIdentity {
     );
   }
 
+  /// Restores a P-256 identity from JSON.
   factory P256Identity.fromJSON(String json) {
     final parsed = jsonDecode(json);
     if (parsed is List) {
@@ -106,6 +127,7 @@ class P256Identity extends SignIdentity {
     throw ArgumentError.value(jsonEncode(json), 'json', 'Invalid json');
   }
 
+  /// Creates an identity from raw public and private key bytes.
   factory P256Identity.fromKeyPair(
     BinaryBlob publicKey,
     BinaryBlob privateKey,
@@ -121,6 +143,7 @@ class P256Identity extends SignIdentity {
   SigningFunc? _signingFunc;
   VerifyFunc? _verifyFunc;
 
+  /// Derives a P-256 identity from a raw [secretKey].
   static Future<P256Identity> fromSecretKey(Uint8List secretKey) async {
     final kp = await getECkeyFromPrivateKey(secretKey);
     final identity = P256Identity.fromKeyPair(
@@ -130,10 +153,12 @@ class P256Identity extends SignIdentity {
     return identity;
   }
 
+  /// Overrides the default signing implementation.
   void setSigningFunc(SigningFunc func) {
     _signingFunc = func;
   }
 
+  /// Overrides the default verification implementation.
   void setVerifyFunc(VerifyFunc func) {
     _verifyFunc = func;
   }
@@ -163,6 +188,7 @@ class P256Identity extends SignIdentity {
     return signP256Async(blob, _privateKey);
   }
 
+  /// Verifies [signature] against [message].
   Future<bool> verify(Uint8List signature, Uint8List message) {
     if (_verifyFunc != null) {
       return _verifyFunc!(
@@ -179,6 +205,7 @@ class P256Identity extends SignIdentity {
   }
 }
 
+/// Signs [blob] with a P-256 private [seed].
 Future<Uint8List> signP256Async(
   Uint8List blob,
   Uint8List seed,
@@ -189,6 +216,7 @@ Future<Uint8List> signP256Async(
   return result.signature!;
 }
 
+/// Verifies a P-256 [signature] for [blob] and [publicKey].
 Future<bool> verifyP256Async(
   Uint8List blob,
   Uint8List signature,

--- a/packages/agent_dart_base/lib/identity/schnorr.dart
+++ b/packages/agent_dart_base/lib/identity/schnorr.dart
@@ -9,32 +9,44 @@ import '../utils/extension.dart';
 import '../wallet/keysmith.dart';
 import 'der.dart';
 
+/// A Schnorr key pair containing public and private key material.
 class SchnorrKeyPair extends KeyPair {
+  /// Creates a Schnorr key pair.
   const SchnorrKeyPair({required super.publicKey, required super.secretKey});
 
+  /// Serializes the key pair as `[publicKeyDerHex, secretKeyHex]`.
   List<String> toJson() {
     return [publicKey.toDer().toHex(), secretKey.toHex()];
   }
 }
 
+/// A BIP340-style Schnorr public key.
 class SchnorrPublicKey implements PublicKey {
+  /// Creates a Schnorr public key from raw key bytes.
   SchnorrPublicKey(this.rawKey);
 
+  /// Creates a Schnorr public key from raw key bytes.
   factory SchnorrPublicKey.fromRaw(BinaryBlob rawKey) {
     return SchnorrPublicKey(rawKey);
   }
 
+  /// Creates a Schnorr public key from DER-encoded key bytes.
   factory SchnorrPublicKey.fromDer(BinaryBlob derKey) {
     return SchnorrPublicKey(SchnorrPublicKey.derDecode(derKey));
   }
 
+  /// Creates a Schnorr public key from another [PublicKey].
   factory SchnorrPublicKey.from(PublicKey key) {
     return SchnorrPublicKey.fromDer(key.toDer());
   }
 
+  /// Raw Schnorr public key bytes.
   final BinaryBlob rawKey;
+
+  /// DER-encoded form of [rawKey].
   late final derKey = SchnorrPublicKey.derEncode(rawKey);
 
+  /// DER-encodes a raw Schnorr [publicKey].
   static Uint8List derEncode(BinaryBlob publicKey) {
     // BIP340 Schnorr scheme doesn't apply to ASN.1 standard, although other
     // form of oid existed, we just borrow secp256k1 as ref.
@@ -43,22 +55,28 @@ class SchnorrPublicKey implements PublicKey {
     return bytesWrapDer(publicKey, oidSecp256k1);
   }
 
+  /// Decodes a DER-encoded Schnorr [publicKey].
   static Uint8List derDecode(BinaryBlob publicKey) {
     return bytesUnwrapDer(publicKey, oidSecp256k1);
   }
 
+  /// Returns the DER encoding of this public key.
   @override
   Uint8List toDer() => derKey;
 
+  /// Returns the raw Schnorr public key bytes.
   Uint8List toRaw() => rawKey;
 }
 
+/// A signing identity backed by a Schnorr private key.
 class SchnorrIdentity extends SignIdentity {
+  /// Creates a Schnorr identity from a public key and private key bytes.
   SchnorrIdentity(
     PublicKey publicKey,
     this._privateKey,
   ) : _publicKey = SchnorrPublicKey.from(publicKey);
 
+  /// Restores an identity from a parsed `[publicKeyHex, privateKeyHex]` list.
   factory SchnorrIdentity.fromParsedJson(List<String> obj) {
     return SchnorrIdentity(
       SchnorrPublicKey.fromRaw(blobFromHex(obj[0])),
@@ -66,6 +84,7 @@ class SchnorrIdentity extends SignIdentity {
     );
   }
 
+  /// Restores a Schnorr identity from JSON.
   factory SchnorrIdentity.fromJSON(String json) {
     final parsed = jsonDecode(json);
     if (parsed is List) {
@@ -99,6 +118,7 @@ class SchnorrIdentity extends SignIdentity {
     throw ArgumentError.value(jsonEncode(json), 'json', 'Invalid json');
   }
 
+  /// Creates an identity from raw public and private key bytes.
   factory SchnorrIdentity.fromKeyPair(
     BinaryBlob publicKey,
     BinaryBlob privateKey,
@@ -112,6 +132,7 @@ class SchnorrIdentity extends SignIdentity {
   final SchnorrPublicKey _publicKey;
   final BinaryBlob _privateKey;
 
+  /// Derives a Schnorr identity from a raw [secretKey].
   static Future<SchnorrIdentity> fromSecretKey(Uint8List secretKey) async {
     final kp = await getECkeyFromPrivateKey(secretKey);
     final identity = SchnorrIdentity.fromKeyPair(
@@ -143,6 +164,7 @@ class SchnorrIdentity extends SignIdentity {
     return signSchnorrAsync(blob, _privateKey);
   }
 
+  /// Verifies [signature] against [message].
   Future<bool> verify(Uint8List signature, Uint8List message) {
     return verifySchnorrAsync(
       message,
@@ -152,6 +174,7 @@ class SchnorrIdentity extends SignIdentity {
   }
 }
 
+/// Signs [blob] with a Schnorr private [seed].
 Future<Uint8List> signSchnorrAsync(
   Uint8List blob,
   Uint8List seed, {
@@ -163,6 +186,7 @@ Future<Uint8List> signSchnorrAsync(
   return result.signature!;
 }
 
+/// Verifies a Schnorr [signature] for [blob] and [publicKey].
 Future<bool> verifySchnorrAsync(
   Uint8List blob,
   Uint8List signature,

--- a/packages/agent_dart_base/lib/identity/secp256k1.dart
+++ b/packages/agent_dart_base/lib/identity/secp256k1.dart
@@ -24,14 +24,18 @@ BigInt _bytesToUnsignedInt(Uint8List bytes) {
 // final ECDomainParameters params = ECCurve_secp256k1();
 final BigInt _halfCurveOrder = secp256k1Params.n >> 1;
 
+/// A secp256k1 key pair containing public and private key material.
 class Secp256k1KeyPair extends KeyPair {
+  /// Creates a secp256k1 key pair.
   const Secp256k1KeyPair({required super.publicKey, required super.secretKey});
 
+  /// Serializes the key pair as `[publicKeyDerHex, secretKeyHex]`.
   List<String> toJson() {
     return [publicKey.toDer().toHex(), secretKey.toHex()];
   }
 }
 
+/// A signing identity backed by a secp256k1 private key.
 class Secp256k1KeyIdentity extends SignIdentity {
   /// [Secp256k1KeyIdentity.fromRaw] and [Secp256k1KeyIdentity.fromDer]
   /// should not be used for instantiation in this constructor.
@@ -40,6 +44,7 @@ class Secp256k1KeyIdentity extends SignIdentity {
     this._privateKey,
   ) : _publicKey = Secp256k1PublicKey.from(publicKey);
 
+  /// Restores an identity from a parsed `[publicKeyHex, privateKeyHex]` list.
   factory Secp256k1KeyIdentity.fromParsedJson(List<String> obj) {
     return Secp256k1KeyIdentity(
       Secp256k1PublicKey.fromRaw(blobFromHex(obj[0])),
@@ -47,6 +52,7 @@ class Secp256k1KeyIdentity extends SignIdentity {
     );
   }
 
+  /// Restores a secp256k1 identity from JSON.
   factory Secp256k1KeyIdentity.fromJSON(String json) {
     final parsed = jsonDecode(json);
     if (parsed is List) {
@@ -80,6 +86,7 @@ class Secp256k1KeyIdentity extends SignIdentity {
     throw ArgumentError.value(jsonEncode(json), 'json', 'Invalid json');
   }
 
+  /// Creates an identity from raw public and private key bytes.
   factory Secp256k1KeyIdentity.fromKeyPair(
     BinaryBlob publicKey,
     BinaryBlob privateKey,
@@ -93,6 +100,7 @@ class Secp256k1KeyIdentity extends SignIdentity {
   final Secp256k1PublicKey _publicKey;
   final BinaryBlob _privateKey;
 
+  /// Derives a secp256k1 identity from a raw [secretKey].
   static Future<Secp256k1KeyIdentity> fromSecretKey(Uint8List secretKey) async {
     final kp = await getECkeyFromPrivateKey(secretKey);
     final identity = Secp256k1KeyIdentity.fromKeyPair(
@@ -125,38 +133,51 @@ class Secp256k1KeyIdentity extends SignIdentity {
   }
 }
 
+/// A secp256k1 public key that can be encoded for IC request signing.
 class Secp256k1PublicKey implements PublicKey {
+  /// Creates a public key from raw secp256k1 key bytes.
   Secp256k1PublicKey(this.rawKey);
 
+  /// Creates a public key from raw secp256k1 key bytes.
   factory Secp256k1PublicKey.fromRaw(BinaryBlob rawKey) {
     return Secp256k1PublicKey(rawKey);
   }
 
+  /// Creates a public key from DER-encoded secp256k1 key bytes.
   factory Secp256k1PublicKey.fromDer(BinaryBlob derKey) {
     return Secp256k1PublicKey(Secp256k1PublicKey.derDecode(derKey));
   }
 
+  /// Creates a secp256k1 public key from another [PublicKey].
   factory Secp256k1PublicKey.from(PublicKey key) {
     return Secp256k1PublicKey.fromDer(key.toDer());
   }
 
+  /// Raw secp256k1 public key bytes.
   final BinaryBlob rawKey;
+
+  /// DER-encoded form of [rawKey].
   late final derKey = Secp256k1PublicKey.derEncode(rawKey);
 
+  /// DER-encodes a raw secp256k1 [publicKey].
   static Uint8List derEncode(BinaryBlob publicKey) {
     return bytesWrapDer(publicKey, oidSecp256k1);
   }
 
+  /// Decodes a DER-encoded secp256k1 [publicKey].
   static Uint8List derDecode(BinaryBlob publicKey) {
     return bytesUnwrapDer(publicKey, oidSecp256k1);
   }
 
+  /// Returns the DER encoding of this public key.
   @override
   Uint8List toDer() => derKey;
 
+  /// Returns the raw secp256k1 public key bytes.
   Uint8List toRaw() => rawKey;
 }
 
+/// Signs [message] with [secretKey] using deterministic ECDSA over secp256k1.
 Uint8List signSecp256k1(String message, BinaryBlob secretKey) {
   final blob = message.plainToU8a(useDartEncode: true);
   final digest = SHA256Digest();
@@ -183,6 +204,7 @@ Uint8List signSecp256k1(String message, BinaryBlob secretKey) {
   return u8aConcat([rU8a, sU8a]);
 }
 
+/// Signs [blob] with a secp256k1 private [seed].
 Future<Uint8List> signSecp256k1Async(Uint8List blob, Uint8List seed) async {
   final result = await secp256K1Sign(
     req: Secp256k1SignWithSeedReq(seed: seed, msg: blob),
@@ -190,6 +212,7 @@ Future<Uint8List> signSecp256k1Async(Uint8List blob, Uint8List seed) async {
   return result.signature!;
 }
 
+/// Creates a recoverable secp256k1 signature for [blob].
 Future<Uint8List> signSecp256k1Recoverable(
   Uint8List blob,
   Uint8List seed,
@@ -200,6 +223,7 @@ Future<Uint8List> signSecp256k1Recoverable(
   return result.signature!;
 }
 
+/// Signs [blob] with secp256k1 using RNG-backed signing.
 Future<Uint8List> signSecp256k1WithRNG(Uint8List blob, Uint8List bytes) async {
   final result = await secp256K1SignWithRng(
     req: Secp256k1SignWithRngReq(privateBytes: bytes, msg: blob),
@@ -208,6 +232,7 @@ Future<Uint8List> signSecp256k1WithRNG(Uint8List blob, Uint8List bytes) async {
   return result.signature!;
 }
 
+/// Verifies a secp256k1 [signature] for [message] and [publicKey].
 bool verifySecp256k1(
   String message,
   Uint8List signature,
@@ -226,6 +251,7 @@ bool verifySecp256k1(
   return signer.verifySignature(blob, sig);
 }
 
+/// Verifies a secp256k1 [signature] for precomputed message bytes.
 bool verifySecp256k1Blob(
   Uint8List blob,
   Uint8List signature,
@@ -243,6 +269,7 @@ bool verifySecp256k1Blob(
   return signer.verifySignature(blob, sig);
 }
 
+/// Recovers a secp256k1 public key from a prehashed message and signature.
 Future<Uint8List> recoverSecp256k1PubKey(
   Uint8List preHashedMessage,
   Uint8List signature,
@@ -256,6 +283,7 @@ Future<Uint8List> recoverSecp256k1PubKey(
   return result;
 }
 
+/// Computes a secp256k1 ECDH shared secret.
 Future<Uint8List> getECShareSecret(
   Uint8List privateKey,
   Uint8List rawPublicKey,
@@ -269,6 +297,7 @@ Future<Uint8List> getECShareSecret(
   return result;
 }
 
+/// Computes a P-256 ECDH shared secret.
 Future<Uint8List> getP256ShareSecret(
   Uint8List privateKey,
   Uint8List rawPublicKey,

--- a/packages/agent_dart_base/lib/principal/principal.dart
+++ b/packages/agent_dart_base/lib/principal/principal.dart
@@ -8,6 +8,7 @@ import 'utils/sha224.dart';
 
 export 'utils/utils.dart';
 
+/// The supported textual identifier formats used by agent_dart.
 enum IdentifierType { accountIdentifier, principal }
 
 const _suffixSelfAuthenticating = 2;
@@ -17,23 +18,40 @@ const _typeOpaque = 1;
 
 final _emptySubAccount = Uint8List(32);
 
+/// An Internet Computer principal identifier.
+///
+/// Principals identify canisters, users, and other IC entities. A principal can
+/// be converted between its binary representation, canonical textual form, and
+/// account identifier form. Optionally, a principal may also carry a 32-byte
+/// subaccount for account-id derivation.
 class Principal implements Comparable<Principal> {
+  /// Creates a principal from its raw bytes and optional 32-byte [subAccount].
   const Principal(
     this._principal, {
     Uint8List? subAccount,
   })  : assert(subAccount == null || subAccount.length == 32),
         _subAccount = subAccount;
 
+  /// Creates a self-authenticating principal from a public key.
+  ///
+  /// The public key is SHA-224 hashed and suffixed with the IC
+  /// self-authenticating principal type byte.
   factory Principal.selfAuthenticating(Uint8List publicKey) {
     final sha = sha224Hash(publicKey.buffer);
     final u8a = Uint8List.fromList([...sha, _suffixSelfAuthenticating]);
     return Principal(u8a);
   }
 
+  /// Creates the anonymous principal.
   factory Principal.anonymous() {
     return Principal(Uint8List.fromList([_suffixAnonymous]));
   }
 
+  /// Converts [other] into a [Principal].
+  ///
+  /// Accepts canonical principal text, another [Principal], or the serialized
+  /// map shape produced by older agent_dart APIs. Throws [UnreachableError] for
+  /// unsupported values.
   factory Principal.from(Object? other) {
     if (other is String) {
       return Principal.fromText(other);
@@ -45,6 +63,9 @@ class Principal implements Comparable<Principal> {
     throw UnreachableError();
   }
 
+  /// Creates a principal from the first [uSize] bytes of [data].
+  ///
+  /// Throws [RangeError] when [uSize] is larger than the supplied data length.
   factory Principal.create(int uSize, Uint8List data, Uint8List? subAccount) {
     if (uSize > data.length) {
       throw RangeError.range(
@@ -58,6 +79,11 @@ class Principal implements Comparable<Principal> {
     return Principal(data.sublist(0, uSize), subAccount: subAccount);
   }
 
+  /// Parses a principal from hexadecimal bytes and an optional subaccount hex.
+  ///
+  /// [subAccountHex] is left-padded to 32 bytes when supplied. Leading zeros in
+  /// the subaccount are rejected because the textual subaccount representation
+  /// must be canonical.
   factory Principal.fromHex(String hex, {String? subAccountHex}) {
     if (hex.isEmpty) {
       return Principal(Uint8List(0));
@@ -78,6 +104,10 @@ class Principal implements Comparable<Principal> {
     );
   }
 
+  /// Parses a principal from its canonical textual representation.
+  ///
+  /// The parser validates the checksum and canonical formatting, including
+  /// optional subaccount notation.
   factory Principal.fromText(String text) {
     if (text.endsWith('.')) {
       throw ArgumentError(
@@ -133,6 +163,7 @@ class Principal implements Comparable<Principal> {
   final Uint8List _principal;
   final Uint8List? _subAccount;
 
+  /// The principal subaccount, or `null` when it is absent or all zeros.
   Uint8List? get subAccount {
     if (_subAccount case final v when v == null || v.eq(_emptySubAccount)) {
       return null;
@@ -140,6 +171,9 @@ class Principal implements Comparable<Principal> {
     return _subAccount;
   }
 
+  /// Returns this principal with [subAccount] attached.
+  ///
+  /// Passing `null` or an all-zero subaccount returns the current principal.
   Principal newSubAccount(Uint8List? subAccount) {
     if (subAccount == null || subAccount.eq(_emptySubAccount)) {
       return this;
@@ -150,14 +184,18 @@ class Principal implements Comparable<Principal> {
     return this;
   }
 
+  /// Whether this principal is the anonymous principal.
   bool isAnonymous() {
     return _principal.lengthInBytes == 1 && _principal[0] == _suffixAnonymous;
   }
 
+  /// Returns the raw principal bytes.
   Uint8List toUint8List() => _principal;
 
+  /// Returns the raw principal bytes as uppercase hexadecimal.
   String toHex() => _toHexString(_principal).toUpperCase();
 
+  /// Returns the canonical textual representation of this principal.
   String toText() {
     final checksum = _getChecksum(_principal.buffer);
     final bytes = Uint8List.fromList(_principal);
@@ -192,6 +230,7 @@ class Principal implements Comparable<Principal> {
     return buffer.toString();
   }
 
+  /// Derives the 32-byte account identifier for this principal and subaccount.
   Uint8List toAccountId() {
     final hash = SHA224();
     hash.update('\x0Aaccount-id'.plainToU8a());
@@ -236,6 +275,7 @@ class Principal implements Comparable<Principal> {
   bool operator >=(Principal other) => compareTo(other) >= 0;
 }
 
+/// A principal that represents a canister identifier.
 class CanisterId extends Principal {
   CanisterId(Principal pid) : super(pid.toUint8List());
 

--- a/packages/agent_dart_base/lib/wallet/keysmith.dart
+++ b/packages/agent_dart_base/lib/wallet/keysmith.dart
@@ -10,15 +10,24 @@ import '../../identity/identity.dart';
 import '../../principal/principal.dart';
 import '../../utils/extension.dart';
 
+/// Shared secp256k1 curve parameters used for key derivation and signatures.
 final secp256k1Params = ECCurve_secp256k1();
 
+/// BIP-44 coin type constants used by key derivation helpers.
 abstract class CoinType {
+  /// Internet Computer coin type.
   static const icp = 223;
+
+  /// Ethereum coin type.
   static const eth = 60;
+
+  /// Bitcoin coin type.
   static const btc = 0;
 }
 
+/// Derived elliptic-curve key material.
 class ECKeys {
+  /// Creates a derived key container.
   const ECKeys({
     this.ecChainCode,
     this.ecPrivateKey,
@@ -29,27 +38,44 @@ class ECKeys {
     this.extendedECPublicKey,
   });
 
+  /// Chain code for extended key derivation.
   final Uint8List? ecChainCode;
+
+  /// Raw private key bytes.
   final Uint8List? ecPrivateKey;
+
+  /// Raw secp256k1 public key bytes.
   final Uint8List? ecPublicKey;
+
+  /// Raw P-256 public key bytes.
   final Uint8List? ecP256PublicKey;
+
+  /// Raw Schnorr public key bytes.
   final Uint8List? ecSchnorrPublicKey;
+
+  /// Compressed secp256k1 public key bytes.
   final Uint8List? ecCompressedPublicKey;
+
+  /// Extended public key in base58 form.
   final String? extendedECPublicKey;
 
+  /// ICP account identifier derived from [ecPublicKey].
   Uint8List? get accountId =>
       ecPublicKey != null ? getAccountIdFromRawPublicKey(ecPublicKey!) : null;
 
+  /// Self-authenticating principal derived from [ecPublicKey].
   String? get ecPrincipal =>
       ecPublicKey != null ? getPrincipalFromECPublicKey(ecPublicKey!) : null;
 }
 
+/// Returns the base BIP-44 derivation path for [coinType].
 String getPathWithCoinType({
   int coinType = CoinType.icp,
 }) {
   return "m/44'/$coinType'/0'";
 }
 
+/// Generates a BIP-39 mnemonic phrase.
 String generateMnemonic({
   bip39.Language language = bip39.Language.english,
   String passphrase = '',
@@ -63,6 +89,7 @@ String generateMnemonic({
   return mnemonic.sentence;
 }
 
+/// Validates a BIP-39 mnemonic phrase.
 bool validateMnemonic(
   String value, {
   bip39.Language language = bip39.Language.english,
@@ -80,6 +107,7 @@ bool validateMnemonic(
   }
 }
 
+/// Converts a BIP-39 [phrase] into seed bytes.
 Uint8List mnemonicToSeed(
   String phrase, {
   bip39.Language language = bip39.Language.english,
@@ -94,30 +122,36 @@ Uint8List mnemonicToSeed(
   return Uint8List.fromList(mnemonic.seed);
 }
 
+/// Derives an IC principal from a raw secp256k1 [publicKey].
 String getPrincipalFromECPublicKey(Uint8List publicKey) {
   final secp256k1Pub = Secp256k1PublicKey.fromRaw(publicKey).toDer();
   final auth = Principal.selfAuthenticating(secp256k1Pub);
   return auth.toText();
 }
 
+/// Derives an ICP account identifier from a raw secp256k1 [publicKey].
 Uint8List getAccountIdFromRawPublicKey(Uint8List publicKey) {
   final der = Secp256k1PublicKey.fromRaw(publicKey).toDer();
   return getAccountIdFromDerKey(der);
 }
 
+/// Derives an ICP account identifier from a raw Ed25519 [publicKey].
 Uint8List getAccountIdFromEd25519PublicKey(Uint8List publicKey) {
   final der = Ed25519PublicKey.fromRaw(publicKey).toDer();
   return getAccountIdFromDerKey(der);
 }
 
+/// Derives an ICP account identifier from a DER-encoded public key.
 Uint8List getAccountIdFromDerKey(Uint8List der) {
   return Principal.selfAuthenticating(der).toAccountId();
 }
 
+/// Derives an ICP account identifier from a principal text [id].
 Uint8List getAccountIdFromPrincipalID(String id) {
   return Principal.fromText(id).toAccountId();
 }
 
+/// Derives secp256k1 key material from a mnemonic phrase.
 ECKeys getECKeys(
   String mnemonic, {
   bip39.Language language = bip39.Language.english,
@@ -137,6 +171,7 @@ ECKeys getECKeys(
   return ecKeysfromSeed(seed, index: index, coinType: coinType);
 }
 
+/// Derives secp256k1, Schnorr, and P-256 key material from a phrase.
 Future<ECKeys> getECKeysAsync(
   String phrase, {
   String passphrase = '',
@@ -169,6 +204,7 @@ Future<ECKeys> getECKeysAsync(
   );
 }
 
+/// Derives public keys for multiple curves from a raw private key.
 Future<ECKeys> getECkeyFromPrivateKey(Uint8List prv) async {
   final kp = await ffi.secp256K1FromSeed(
     req: ffi.Secp256k1FromSeedReq(seed: prv),
@@ -189,6 +225,7 @@ Future<ECKeys> getECkeyFromPrivateKey(Uint8List prv) async {
   );
 }
 
+/// Derives secp256k1 keys from raw BIP-39 seed bytes.
 ECKeys ecKeysfromSeed(
   Uint8List seed, {
   int index = 0,
@@ -213,6 +250,7 @@ ECKeys ecKeysfromSeed(
   );
 }
 
+/// Derives a public key from a secp256k1 [privateKey].
 Uint8List? getPublicFromPrivateKey(
   Uint8List privateKey, [
   bool compress = false,
@@ -221,6 +259,7 @@ Uint8List? getPublicFromPrivateKey(
   return getPublicFromPrivateKeyBigInt(privateKeyNum, compress);
 }
 
+/// Derives a public key from a secp256k1 private key integer.
 Uint8List? getPublicFromPrivateKeyBigInt(
   BigInt bigint, [
   bool compress = false,
@@ -233,6 +272,7 @@ Uint8List? getPublicFromPrivateKeyBigInt(
   }
 }
 
+/// Derives a DER-encoded secp256k1 public key via the native FFI bridge.
 Future<Uint8List> getDerFromFFI(Uint8List seed) async {
   final ffiIdentity = await ffi.secp256K1FromSeed(
     req: ffi.Secp256k1FromSeedReq(seed: seed),
@@ -240,6 +280,7 @@ Future<Uint8List> getDerFromFFI(Uint8List seed) async {
   return ffiIdentity.derEncodedPublicKey;
 }
 
+/// Derives a Schnorr public key via the native FFI bridge.
 Future<Uint8List> getSchnorrPubFromFFI(Uint8List seed) async {
   final ffiIdentity = await ffi.schnorrFromSeed(
     req: ffi.SchnorrFromSeedReq(seed: seed),
@@ -247,6 +288,7 @@ Future<Uint8List> getSchnorrPubFromFFI(Uint8List seed) async {
   return ffiIdentity.publicKeyHash;
 }
 
+/// Derives a DER-encoded P-256 public key via the native FFI bridge.
 Future<Uint8List> getP256DerPubFromFFI(Uint8List seed) async {
   final ffiIdentity = await ffi.p256FromSeed(
     req: ffi.P256FromSeedReq(seed: seed),

--- a/packages/agent_dart_base/lib/wallet/ledger.dart
+++ b/packages/agent_dart_base/lib/wallet/ledger.dart
@@ -13,9 +13,12 @@ import '../utils/u8a.dart';
 
 const _accountIdentifier = IDL.Text;
 
+/// Duration value used by ledger canister payloads.
 class PayloadDuration {
+  /// Creates a duration from seconds and nanoseconds.
   const PayloadDuration({required this.secs, required this.nanos});
 
+  /// Creates a duration from Candid JSON-like data.
   factory PayloadDuration.fromJson(Map map) {
     return PayloadDuration(secs: map['secs'], nanos: map['nanos']);
   }
@@ -31,13 +34,16 @@ class PayloadDuration {
   }
 }
 
+/// Archive canister options for ledger initialization.
 class ArchiveOptions {
+  /// Creates archive options.
   const ArchiveOptions({
     required this.controllerId,
     this.maxMessageSizeBytes,
     this.nodeMaxMemorySizeBytes,
   });
 
+  /// Creates archive options from Candid JSON-like data.
   factory ArchiveOptions.fromJson(Map map) {
     return ArchiveOptions(
       controllerId: map['controller_id'],
@@ -65,9 +71,12 @@ class ArchiveOptions {
   }
 }
 
+/// ICP token amount represented in e8s.
 class ICPTs {
+  /// Creates an ICP amount from e8s.
   const ICPTs({required this.e8s});
 
+  /// Creates an ICP amount from Candid JSON-like data.
   factory ICPTs.fromJson(Map map) {
     return ICPTs(e8s: map['e8s']);
   }
@@ -81,6 +90,7 @@ class ICPTs {
   }
 }
 
+/// Initialization payload for the ledger canister.
 class LedgerCanisterInitPayload {
   const LedgerCanisterInitPayload({
     required this.sendWhitelist,
@@ -147,6 +157,7 @@ class LedgerCanisterInitPayload {
   }
 }
 
+/// Arguments for the legacy ledger account balance endpoint.
 class AccountBalanceArgs {
   const AccountBalanceArgs({required this.account});
 
@@ -163,10 +174,12 @@ class AccountBalanceArgs {
   }
 }
 
+/// Candid type for a ledger subaccount.
 final SubAccount = IDL.Vec(IDL.Nat8);
 
 const _blockHeight = IDL.Nat64;
 
+/// Arguments for notifying a canister about a ledger payment.
 class NotifyCanisterArgs {
   const NotifyCanisterArgs({
     this.toSubAccount,
@@ -213,6 +226,7 @@ class NotifyCanisterArgs {
 
 const _memo = IDL.Nat64;
 
+/// Ledger timestamp represented in nanoseconds.
 class TimeStamp {
   const TimeStamp({required this.timestampNanos});
 
@@ -233,6 +247,7 @@ class TimeStamp {
   }
 }
 
+/// Arguments for the legacy ledger send endpoint.
 class SendArgs {
   const SendArgs({
     required this.to,
@@ -286,8 +301,10 @@ class SendArgs {
   }
 }
 
+/// Candid type for the modern binary account identifier.
 final AccountIdentifierNew = IDL.Vec(IDL.Nat8);
 
+/// Arguments for the modern ledger account balance endpoint.
 class AccountBalanceArgsNew {
   const AccountBalanceArgsNew({required this.account});
 
@@ -304,6 +321,7 @@ class AccountBalanceArgsNew {
   }
 }
 
+/// Ledger token amount represented in e8s.
 class Tokens {
   const Tokens({required this.e8s});
 
@@ -320,6 +338,7 @@ class Tokens {
   }
 }
 
+/// Arguments for the modern ledger transfer endpoint.
 class TransferArgs {
   const TransferArgs({
     required this.to,
@@ -379,6 +398,7 @@ class TransferArgs {
 
 const _blockIndex = IDL.Nat64;
 
+/// Error returned by the ledger transfer endpoint.
 class TransferError {
   const TransferError({
     this.txTooOld,
@@ -430,6 +450,7 @@ class TransferError {
   }
 }
 
+/// Result returned by the ledger transfer endpoint.
 class TransferResult {
   const TransferResult({this.ok, this.err});
 
@@ -454,6 +475,7 @@ class TransferResult {
   }
 }
 
+/// Candid service definition for the ICP ledger canister.
 final Service ledgerIdl = IDL.Service({
   'account_balance': IDL.Func(
     [AccountBalanceArgsNew.idl],
@@ -470,6 +492,7 @@ final Service ledgerIdl = IDL.Service({
   'transfer': IDL.Func([TransferArgs.idl], [TransferResult.idl], []),
 });
 
+/// Method names exposed by the ICP ledger canister.
 class LedgerMethods {
   const LedgerMethods._();
 
@@ -480,6 +503,7 @@ class LedgerMethods {
   static const transfer = 'transfer';
 }
 
+/// Optional values used when sending or transferring ICP.
 class SendOpts {
   const SendOpts({
     this.fee,
@@ -496,25 +520,31 @@ class SendOpts {
   int? get createAt => createAtTime?.millisecondsSinceEpoch;
 }
 
+/// Convenience wrapper around ICP ledger canister calls.
 class Ledger {
+  /// Creates an unattached ledger wrapper.
   Ledger();
 
+  /// Creates a ledger wrapper attached to an [AgentFactory].
   factory Ledger.hook(AgentFactory agent) {
     return Ledger()..setAgent(agent);
   }
 
   late AgentFactory agent;
 
+  /// Sets the agent used for ledger calls.
   void setAgent(AgentFactory agent) {
     this.agent = agent;
   }
 
+  /// Sets the signing identity on the underlying agent.
   void setIdentity(SignIdentity? id) {
     if (id != null) {
       agent.getAgent().setIdentity(id);
     }
   }
 
+  /// Returns a legacy ICP balance for [accountId].
   static Future<ICPTs> getBalance({
     required AgentFactory agent,
     required String accountId,
@@ -530,6 +560,7 @@ class Ledger {
     throw StateError('Request failed with the result: $res.');
   }
 
+  /// Returns an ICP balance for an account identifier or principal.
   static Future<Tokens> accountBalance({
     required AgentFactory agent,
     required String accountIdOrPrincipal,
@@ -549,6 +580,7 @@ class Ledger {
     throw StateError('Request failed with the result: $res.');
   }
 
+  /// Sends ICP using the legacy ledger `send_dfx` method.
   static Future<BigInt> send({
     required AgentFactory agent,
     required String to,
@@ -584,6 +616,7 @@ class Ledger {
     throw StateError('Request failed with the result: $res.');
   }
 
+  /// Transfers ICP using the modern ledger `transfer` method.
   static Future<TransferResult> transfer({
     required AgentFactory agent,
     required String to,

--- a/packages/agent_dart_base/lib/wallet/pem.dart
+++ b/packages/agent_dart_base/lib/wallet/pem.dart
@@ -12,15 +12,22 @@ import '../utils/extension.dart';
 const String _beginECPrivateKey = '-----BEGIN EC PRIVATE KEY-----';
 const String _beginPrivateKey = '-----BEGIN PRIVATE KEY-----';
 
+/// Supported PEM private key types.
 enum KeyType { ed25519, secp265k1 }
 
+/// Parsed PEM file content and detected key type.
 class PemFile {
+  /// Creates a parsed PEM file value.
   const PemFile(this.rawString, this.keyType);
 
+  /// PEM body without the leading header marker.
   final String rawString;
+
+  /// Detected key type.
   final KeyType keyType;
 }
 
+/// Reads a PEM file from [path] and detects its private key type.
 Future<PemFile> getPemFile(String path) async {
   final pem = await File(path).readAsString();
   if (pem.split(_beginPrivateKey).length > 1) {
@@ -37,6 +44,7 @@ Future<PemFile> getPemFile(String path) async {
   throw UnsupportedError('$path does not have a supported PEM type.');
 }
 
+/// Creates an Ed25519 identity from a PEM private key body.
 Future<Ed25519KeyIdentity> ed25519KeyIdentityFromPem(String pem) async {
   final privateKeyPem = pem
       .replaceAll('-----END PRIVATE KEY-----', '')
@@ -53,6 +61,7 @@ Future<Ed25519KeyIdentity> ed25519KeyIdentityFromPem(String pem) async {
   return Ed25519KeyIdentity.generate(res);
 }
 
+/// Creates a secp256k1 identity from a PEM private key body.
 Future<Secp256k1KeyIdentity> secp256k1KeyIdentityFromPem(String pem) async {
   final pem2 = _beginECPrivateKey + pem;
   final key = _ecPrivateKeyFromPem(pem2).d;

--- a/packages/agent_dart_base/lib/wallet/phrase.dart
+++ b/packages/agent_dart_base/lib/wallet/phrase.dart
@@ -4,9 +4,12 @@ import 'package:agent_dart_ffi/agent_dart_ffi.dart';
 
 import 'keysmith.dart';
 
+/// BIP-39 mnemonic phrase helper.
 class Phrase {
+  /// Creates a phrase from a validated mnemonic string.
   Phrase(this.mnemonic) : _list = mnemonic.trim().split(' ');
 
+  /// Generates a new 12- or 24-word mnemonic phrase.
   factory Phrase.generate({int length = 24}) {
     assert(length == 12 || length == 24);
     return Phrase.fromString(
@@ -14,6 +17,7 @@ class Phrase {
     );
   }
 
+  /// Validates and creates a phrase from [phrase].
   factory Phrase.fromString(String phrase) {
     final arr = phrase.trim().split(' ');
     final invalidWords = <String>[];
@@ -33,13 +37,17 @@ class Phrase {
     return Phrase(phrase);
   }
 
+  /// Raw mnemonic phrase.
   final String mnemonic;
   final List<String> _list;
 
+  /// Number of words in the phrase.
   int get length => _list.length;
 
+  /// Phrase words as a list.
   List<String> get list => _list;
 
+  /// Converts the phrase to seed bytes using an optional [passphrase].
   Future<Uint8List> toSeed({String passphrase = ''}) {
     return mnemonicPhraseToSeed(
       req: PhraseToSeedReq(
@@ -49,6 +57,7 @@ class Phrase {
     );
   }
 
+  /// Derives private key bytes for a BIP-44 [coinType] and [index].
   Future<Uint8List> toWIFByCoin({
     String passphrase = '',
     int index = 0,
@@ -64,6 +73,7 @@ class Phrase {
     );
   }
 
+  /// Derives private key bytes from a custom [basePath] and [index].
   Future<Uint8List> toWIFByPath({
     String passphrase = '',
     int index = 0,
@@ -79,13 +89,18 @@ class Phrase {
   }
 }
 
+/// Exception thrown when a mnemonic phrase is invalid.
 class PhaseException implements Exception {
+  /// Creates a phrase validation exception.
   const PhaseException({
     required this.message,
     this.wordList,
   });
 
+  /// Validation error message.
   final String message;
+
+  /// Invalid words, when validation failed because of unknown mnemonic words.
   final List<String>? wordList;
 
   @override

--- a/packages/agent_dart_base/lib/wallet/signer.dart
+++ b/packages/agent_dart_base/lib/wallet/signer.dart
@@ -9,10 +9,13 @@ import 'keysmith.dart';
 import 'rosetta.dart';
 import 'types.dart';
 
+/// Callback invoked with optional signing progress or result data.
 typedef SigningCallback = void Function([dynamic data]);
 
+/// Supported signature schemes for wallet payload signing.
 enum SignType { ecdsa, ed25519 }
 
+/// Source of imported wallet key material.
 enum SourceType { ii, plug, keySmith, base }
 
 /// [CurveType] is the type of cryptographic curve associated with a [WalletPublicKey].
@@ -21,15 +24,21 @@ enum SourceType { ii, plug, keySmith, base }
 ///  * [all] both above.
 enum CurveType { secp256k1, ed25519, all }
 
+/// Base interface for wallet signers.
 abstract class Signer<T extends SignablePayload, R> {
+  /// Creates a signer abstraction.
   const Signer();
 
+  /// Whether the signer is currently locked.
   bool? get isLocked;
 
+  /// Unlocks the signer using [passphrase] and an optional serialized keystore.
   Future<void>? unlock(String passphrase, {String? keystore});
 
+  /// Locks the signer, optionally encrypting key material with [passphrase].
   Future<void>? lock(String? passphrase);
 
+  /// Signs [payload] with the selected [signType].
   Future<R> sign(
     T payload, {
     SignType? signType = SignType.ed25519,
@@ -37,24 +46,34 @@ abstract class Signer<T extends SignablePayload, R> {
   });
 }
 
+/// Base signer tied to a concrete account and signable payload type.
 abstract class BaseSigner<T extends BaseAccount, R extends SignablePayload, E>
     extends Signer<R, E> {
+  /// Creates a base signer abstraction.
   const BaseSigner();
 }
 
+/// Base wallet account abstraction used by signers.
 abstract class BaseAccount {
+  /// Creates a base account abstraction.
   const BaseAccount();
 
+  /// Returns the Ed25519 identity for this account, when available.
   Ed25519KeyIdentity? getIdentity();
 
+  /// Returns the secp256k1 identity for this account, when available.
   Secp256k1KeyIdentity? getEcIdentity();
 
+  /// Serializes this account.
   Map<String, dynamic> toJson();
 
+  /// Returns derived elliptic-curve key material, when available.
   ECKeys? getEcKeys();
 }
 
+/// ICP wallet account backed by mnemonic or seed-derived identities.
 class ICPAccount extends BaseAccount {
+  /// Creates an ICP account container for [curveType].
   ICPAccount({this.curveType = CurveType.ed25519});
 
   bool isLocked = false;
@@ -71,6 +90,7 @@ class ICPAccount extends BaseAccount {
   ECKeys? get ecKeys => _ecKeys;
   ECKeys? _ecKeys;
 
+  /// Creates an account from raw seed bytes.
   static Future<ICPAccount> fromSeed(
     Uint8List seed, {
     int? index,
@@ -93,6 +113,7 @@ class ICPAccount extends BaseAccount {
       .._phrase = '';
   }
 
+  /// Creates an account from a mnemonic phrase.
   static Future<ICPAccount> fromPhrase(
     String phrase, {
     String passphrase = '',
@@ -144,6 +165,7 @@ class ICPAccount extends BaseAccount {
   @override
   ECKeys? getEcKeys() => _ecKeys;
 
+  /// Encrypts and clears in-memory key material.
   Future<void> lock(String? passphrase) async {
     _keystore = await encodePhrase(_phrase!, password: passphrase);
     _phrase = null;
@@ -153,6 +175,7 @@ class ICPAccount extends BaseAccount {
     isLocked = true;
   }
 
+  /// Restores key material from the encrypted keystore.
   Future<void> unlock(String passphrase, {String? keystore}) async {
     try {
       if (_keystore == null) {
@@ -180,16 +203,19 @@ class ICPAccount extends BaseAccount {
   }
 }
 
+/// Signer for ICP Rosetta construction payloads.
 class ICPSigner extends BaseSigner<ICPAccount, ConstructionPayloadsResponse,
     CombineSignedTransactionResult> {
   ICPSigner._();
 
+  /// Creates a signer with a newly generated mnemonic phrase.
   static Future<ICPSigner> create({
     CurveType curveType = CurveType.ed25519,
   }) {
     return ICPSigner.fromPhrase(generateMnemonic(), curveType: curveType);
   }
 
+  /// Creates a signer from an existing mnemonic phrase.
   static Future<ICPSigner> fromPhrase(
     String phrase, {
     String passphrase = '',
@@ -210,6 +236,7 @@ class ICPSigner extends BaseSigner<ICPAccount, ConstructionPayloadsResponse,
       .._acc = acc;
   }
 
+  /// Creates a signer from raw seed bytes.
   static Future<ICPSigner> fromSeed(
     Uint8List seed, {
     int? index = 0,
@@ -225,6 +252,7 @@ class ICPSigner extends BaseSigner<ICPAccount, ConstructionPayloadsResponse,
       .._acc = acc;
   }
 
+  /// Imports a phrase using the derivation path for [sourceType].
   static Future<ICPSigner> importPhrase(
     String phrase, {
     int index = 0,
@@ -266,6 +294,7 @@ class ICPSigner extends BaseSigner<ICPAccount, ConstructionPayloadsResponse,
     }
   }
 
+  /// Account used by this signer.
   ICPAccount get account => _acc;
   late ICPAccount _acc;
 
@@ -273,26 +302,36 @@ class ICPSigner extends BaseSigner<ICPAccount, ConstructionPayloadsResponse,
   int? _index;
   SourceType? _sourceType;
 
+  /// Source used to derive this signer's account.
   SourceType? get sourceType => _sourceType;
 
+  /// Account index used during derivation.
   int? get index => _index;
 
+  /// Whether this signer represents an HD account.
   bool get isHD => index == null;
 
+  /// Raw Ed25519 public key as hex.
   String? get idPublicKey => account.identity?.getPublicKey().toRaw().toHex();
 
+  /// DER-encoded Ed25519 public key as hex.
   String? get idPublicKeyDer =>
       account.identity?.getPublicKey().toDer().toHex();
 
+  /// ICP account identifier for the Ed25519 identity.
   String? get idAddress => account.identity?.getAccountId().toHex();
 
+  /// Raw secp256k1 public key as hex.
   String? get ecPublicKey => account.ecIdentity?.getPublicKey().toRaw().toHex();
 
+  /// DER-encoded secp256k1 public key as hex.
   String? get ecPublicKeyDer =>
       account.ecIdentity?.getPublicKey().toDer().toHex();
 
+  /// ICP account identifier for the secp256k1 identity.
   String? get ecAddress => account.ecIdentity?.getAccountId().toHex();
 
+  /// Derives an additional HD account from the signer's phrase.
   Future<ICPAccount> hdCreate({
     String passphrase = '',
     int? index = 0,
@@ -308,6 +347,7 @@ class ICPSigner extends BaseSigner<ICPAccount, ConstructionPayloadsResponse,
     );
   }
 
+  /// Sets the phrase import source type.
   void setSourceType(SourceType type) {
     _sourceType = type;
   }


### PR DESCRIPTION
## Summary

This PR expands the project documentation for `agent_dart` and `agent_dart_base`.

### Included

- Adds API doc comments for core public surfaces:
  - principals and account identifier helpers
  - identity and public key abstractions
  - Ed25519 identity helpers
  - actor/call configuration helpers
  - HTTP agent setup and transport options
- Adds developer-facing guide pages under `docs/`:
  - getting started
  - API overview
  - generating Dart API reference locally
- Adds a GitHub Pages documentation workflow that can publish:
  - guide pages from `docs/`
  - generated `agent_dart` API reference
  - generated `agent_dart_base` API reference
- Updates README documentation links

## Status

Keeping this as a draft while I continue expanding API coverage across the remaining public modules.

## Validation

- `git diff --check`