### PR TITLE
Docs: Document fetch.dart

### DIFF
--- a/packages/agent_dart_base/lib/agent/agent/http/fetch.dart
+++ b/packages/agent_dart_base/lib/agent/agent/http/fetch.dart
@@ -1,3 +1,4 @@
+/// Documents packages/agent_dart_base/lib/agent/agent/http/fetch.dart module purpose, public surface, and usage context
 import 'dart:async';
 import 'dart:typed_data';
 


### PR DESCRIPTION
Documents packages/agent_dart_base/lib/agent/agent/http/fetch.dart module purpose, public surface, and usage context