### PR TITLE
Docs: Document index.dart

### DIFF
--- a/packages/agent_dart_base/lib/agent/canisters/index.dart
+++ b/packages/agent_dart_base/lib/agent/canisters/index.dart
@@ -1,3 +1,4 @@
+/// Documents packages/agent_dart_base/lib/agent/canisters/index.dart module purpose, public surface, and usage context
 export 'asset.dart';
 export 'asset_idl.dart';
 export 'management.dart';


### PR DESCRIPTION
Documents packages/agent_dart_base/lib/agent/canisters/index.dart module purpose, public surface, and usage context